### PR TITLE
feat: add passive forensic analysis command (peat forensic)

### DIFF
--- a/peat/api/forensic_api.py
+++ b/peat/api/forensic_api.py
@@ -1,0 +1,157 @@
+"""
+High-level forensic API — entry point for passive forensic analysis.
+
+Routes forensic inputs (disk images, log files, PCAPs) to the appropriate
+analysis pipeline and manages forensic integrity throughout.
+
+@decision: Designed as a single entry point (forensic_main) that auto-detects
+input type and delegates, rather than requiring users to know which sub-module
+handles their input. This mirrors how `peat pull` auto-detects device types.
+Users can also force a specific mode via CLI flags.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from peat import config, log, state
+from peat.forensic import ForensicInputType, detect_input_type
+from peat.forensic.integrity import (
+    ForensicMetadata,
+    ensure_read_only,
+    generate_forensic_metadata,
+)
+
+
+def forensic_main(args: dict[str, Any]) -> bool:
+    """
+    Main entry point for forensic analysis.
+
+    Determines input type, computes integrity hashes, and dispatches
+    to the appropriate analysis pipeline.
+
+    Args:
+        args: CLI arguments dictionary containing at minimum 'forensic_source'
+              and optionally 'forensic_mode' to force a specific analysis type.
+
+    Returns:
+        True if analysis completed successfully.
+    """
+    source = args.get("forensic_source")
+    if not source:
+        log.critical("No forensic source specified. Run 'peat forensic --help' for usage.")
+        return False
+
+    source_path = Path(source).resolve()
+
+    if not source_path.exists():
+        log.critical(f"Forensic source does not exist: {source_path}")
+        return False
+
+    # Determine input type (auto-detect or forced via CLI flag)
+    forced_mode = args.get("forensic_mode")
+    if forced_mode:
+        try:
+            input_type = ForensicInputType(forced_mode)
+        except ValueError:
+            log.critical(f"Unknown forensic mode: {forced_mode}")
+            return False
+        log.info(f"Forensic mode forced to: {input_type.value}")
+    else:
+        input_type = detect_input_type(source_path)
+        log.info(f"Auto-detected forensic input type: {input_type.value}")
+
+    if input_type == ForensicInputType.UNKNOWN:
+        log.critical(
+            f"Cannot determine input type for: {source_path}. "
+            f"Use --forensic-mode to specify manually."
+        )
+        return False
+
+    # Generate forensic metadata (hashing) for file inputs
+    metadata: ForensicMetadata | None = None
+    if source_path.is_file():
+        ensure_read_only(source_path)
+        metadata = generate_forensic_metadata(
+            source_path,
+            notes=args.get("forensic_notes", ""),
+        )
+        log.info(
+            f"Evidence file: {metadata.file_name} "
+            f"({metadata.file_size:,} bytes, SHA-256: {metadata.sha256[:16]}...)"
+        )
+
+    # Write forensic metadata to output directory
+    if metadata and config.RUN_DIR:
+        _write_forensic_metadata(metadata)
+
+    # Dispatch to appropriate analysis pipeline
+    success = False
+    if input_type == ForensicInputType.DISK_IMAGE:
+        success = _analyze_disk_image(source_path, metadata, args)
+    elif input_type == ForensicInputType.PCAP:
+        success = _analyze_pcap(source_path, metadata, args)
+    elif input_type in (ForensicInputType.LOG_FILE, ForensicInputType.LOG_DIRECTORY):
+        success = _analyze_logs(source_path, metadata, args)
+    elif input_type == ForensicInputType.FIRMWARE:
+        success = _analyze_firmware(source_path, metadata, args)
+
+    if success:
+        log.info(f"Forensic analysis completed successfully for: {source_path.name}")
+    else:
+        log.error(f"Forensic analysis failed for: {source_path.name}")
+
+    return success
+
+
+def _write_forensic_metadata(metadata: ForensicMetadata) -> None:
+    """Write forensic metadata JSON to the output directory."""
+    meta_path = config.RUN_DIR / "forensic-metadata.json"
+    try:
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        meta_path.write_text(json.dumps(metadata.to_dict(), indent=4))
+        log.debug(f"Forensic metadata written to: {meta_path}")
+    except OSError as e:
+        log.warning(f"Failed to write forensic metadata: {e}")
+
+
+def _analyze_disk_image(
+    path: Path, metadata: ForensicMetadata | None, args: dict[str, Any]
+) -> bool:
+    """Dispatch to disk image analysis pipeline."""
+    from peat.forensic.image import analyze_disk_image
+
+    result = analyze_disk_image(image_path=path, metadata=metadata)
+    return len(result.errors) == 0 or len(result.artifacts) > 0
+
+
+def _analyze_pcap(
+    path: Path, metadata: ForensicMetadata | None, args: dict[str, Any]
+) -> bool:
+    """Dispatch to PCAP analysis pipeline."""
+    from peat.forensic.pcap import analyze_pcap
+
+    result = analyze_pcap(pcap_path=path)
+    return len(result.errors) == 0
+
+
+def _analyze_logs(
+    path: Path, metadata: ForensicMetadata | None, args: dict[str, Any]
+) -> bool:
+    """Dispatch to log file analysis pipeline."""
+    from peat.forensic.logs.ingest import ingest_logs
+
+    entries = ingest_logs(path)
+    return len(entries) > 0
+
+
+def _analyze_firmware(
+    path: Path, metadata: ForensicMetadata | None, args: dict[str, Any]
+) -> bool:
+    """Dispatch to firmware analysis pipeline."""
+    from peat.forensic.firmware import analyze_firmware
+
+    result = analyze_firmware(firmware_path=path)
+    return len(result.errors) == 0 or len(result.regions) > 0

--- a/peat/cli_args.py
+++ b/peat/cli_args.py
@@ -404,6 +404,39 @@ peat heat -e -c peat-config.yaml
 """  # End HEAT examples
 
 
+forensic_examples = """
+# Analyze a forensic disk image (E01 format)
+peat forensic ./evidence/workstation.E01
+
+# Analyze a raw disk image
+peat forensic ./evidence/plc_flash.dd
+
+# Analyze a PCAP file with ICS traffic
+peat forensic ./captures/scada_network.pcap
+
+# Analyze ICS log files from a directory
+peat forensic ./logs/sel_relay_exports/
+
+# Force input type when auto-detection is ambiguous
+peat forensic --forensic-mode disk_image ./evidence/unknown_format.bin
+
+# Analyze firmware binary
+peat forensic --forensic-mode firmware ./evidence/plc_firmware.bin
+
+# Add analyst notes to the forensic metadata
+peat forensic --forensic-notes "Case 2026-042, evidence item 3" ./evidence/rtu.E01
+
+# Analyze and upload results to Elasticsearch
+peat forensic -e http://192.0.2.20:9200 ./evidence/historian.vmdk
+
+# Verbose output with named run
+peat forensic -v --run-name case_2026_042 ./evidence/workstation.E01
+
+# Analyze a PCAPNG file
+peat forensic ./captures/modbus_traffic.pcapng
+"""  # End forensic examples
+
+
 ALL_EXAMPLES: dict[str, str] = {
     "scan": scan_examples,
     "pull": pull_examples,
@@ -411,6 +444,7 @@ ALL_EXAMPLES: dict[str, str] = {
     "push": push_examples,
     "pillage": pillage_examples,
     "heat": heat_examples,
+    "forensic": forensic_examples,
 }
 
 
@@ -498,6 +532,20 @@ def build_argument_parser(version: str = "0.0.0") -> argparse.ArgumentParser:
         description=heat_description,
     )
     heat_parser.set_defaults(func="heat")
+
+    # Forensic command
+    forensic_description = (
+        "Passive forensic analysis of OT/ICS artifacts. "
+        "Analyzes disk images (E01, dd, VMDK, VHD), "
+        "ICS/SCADA log files, network packet captures (PCAP/PCAPNG), "
+        "and firmware binaries without touching live devices."
+    )
+    forensic_parser = subparsers.add_parser(
+        name="forensic",
+        help=forensic_description,
+        description=forensic_description,
+    )
+    forensic_parser.set_defaults(func="forensic")
 
     # Config-Builder command
     config_builder_description = (
@@ -1045,6 +1093,36 @@ def build_argument_parser(version: str = "0.0.0") -> argparse.ArgumentParser:
         'use the file without the "-sXXX" in the name as the source.',
     )
     add_list_module_args(pillage_parser)  # Hack to add "--list-*" commands
+
+    # Forensic command arguments
+    forensic_parser.add_argument(
+        "forensic_source",
+        type=str,
+        nargs="?",
+        default=None,
+        metavar="SOURCE",
+        help="Path to forensic evidence: disk image (E01, dd, VMDK, VHD), "
+        "PCAP/PCAPNG file, log file, log directory, or firmware binary.",
+    )
+    forensic_parser.add_argument(
+        "--forensic-mode",
+        type=str,
+        choices=["disk_image", "pcap", "log_file", "log_directory", "firmware"],
+        default=None,
+        dest="forensic_mode",
+        help="Force a specific analysis mode instead of auto-detecting "
+        "from the file extension and magic bytes.",
+    )
+    forensic_parser.add_argument(
+        "--forensic-notes",
+        type=str,
+        default="",
+        dest="forensic_notes",
+        metavar="NOTES",
+        help="Analyst notes to include in the forensic metadata "
+        "(e.g. case number, evidence item ID).",
+    )
+    add_list_module_args(forensic_parser)  # Hack to add "--list-*" commands
 
     # Encrypt command
     encrypt_parser.add_argument(

--- a/peat/cli_main.py
+++ b/peat/cli_main.py
@@ -30,6 +30,7 @@ from peat import (
     state,
     utils,
 )
+from peat.api.forensic_api import forensic_main
 from peat.config_builder import launch_builder
 from peat.heat import HEAT_EXTRACTORS
 
@@ -300,6 +301,9 @@ def oneshot_main(args: dict[str, Any]) -> bool:
 
         elif args["func"] == "pillage":
             return pillage(args["pillage_source"])
+
+        elif args["func"] == "forensic":
+            return forensic_main(args)
 
         else:
             log.critical(f"Unknown func: {args['func']}")

--- a/peat/forensic/__init__.py
+++ b/peat/forensic/__init__.py
@@ -1,0 +1,111 @@
+"""
+PEAT Forensic Module — Passive forensic analysis of OT/ICS artifacts.
+
+Provides three capabilities:
+  - Disk image analysis (E01, dd, VMDK, VHD) with embedded filesystem extraction
+  - ICS/SCADA log file parsing (vendor-specific formats, historian exports)
+  - Network packet capture analysis (PCAP/PCAPNG with ICS protocol dissection)
+
+All operations are read-only and maintain forensic integrity via cryptographic
+hashing and chain-of-custody metadata.
+
+@decision: Created as a top-level package under peat/ rather than extending
+existing modules (pillage/heat/parse) because: (1) forensic operations have
+fundamentally different input sources (files vs live devices), (2) forensic
+integrity requirements (hashing, chain of custody) are cross-cutting concerns
+that don't fit neatly into any single existing module, (3) keeps active and
+passive capabilities cleanly separated for users who need forensic-grade analysis.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from peat import log
+
+
+class ForensicInputType(Enum):
+    """Types of forensic input that PEAT can process."""
+
+    DISK_IMAGE = "disk_image"
+    LOG_FILE = "log_file"
+    LOG_DIRECTORY = "log_directory"
+    PCAP = "pcap"
+    FIRMWARE = "firmware"
+    UNKNOWN = "unknown"
+
+
+# Known file extensions for input type detection
+_IMAGE_EXTENSIONS = {".e01", ".dd", ".raw", ".img", ".vmdk", ".vhd", ".vhdx", ".qcow2"}
+_PCAP_EXTENSIONS = {".pcap", ".pcapng", ".cap"}
+_LOG_EXTENSIONS = {".log", ".csv", ".txt", ".xml", ".cev", ".evt", ".evtx", ".ser"}
+_FIRMWARE_EXTENSIONS = {".bin", ".fw", ".rom", ".spi", ".elf", ".hex"}
+
+
+def detect_input_type(path: Path) -> ForensicInputType:
+    """
+    Auto-detect the type of forensic input based on file extension and magic bytes.
+
+    Args:
+        path: Path to the input file or directory.
+
+    Returns:
+        The detected ForensicInputType.
+    """
+    if path.is_dir():
+        return ForensicInputType.LOG_DIRECTORY
+
+    suffix = path.suffix.lower()
+
+    if suffix in _IMAGE_EXTENSIONS:
+        return ForensicInputType.DISK_IMAGE
+    if suffix in _PCAP_EXTENSIONS:
+        return ForensicInputType.PCAP
+    if suffix in _FIRMWARE_EXTENSIONS:
+        return ForensicInputType.FIRMWARE
+    if suffix in _LOG_EXTENSIONS:
+        return ForensicInputType.LOG_FILE
+
+    # Fall back to magic byte detection for ambiguous extensions
+    return _detect_by_magic(path)
+
+
+def _detect_by_magic(path: Path) -> ForensicInputType:
+    """
+    Detect input type by reading magic bytes from the file header.
+    """
+    try:
+        with open(path, "rb") as f:
+            header = f.read(16)
+    except (OSError, PermissionError) as e:
+        log.warning(f"Cannot read file header for type detection: {e}")
+        return ForensicInputType.UNKNOWN
+
+    if len(header) < 4:
+        return ForensicInputType.UNKNOWN
+
+    # E01 (EnCase) magic: "EVF\x09\x0d\x0a\xff\x00"
+    if header[:5] == b"EVF\x09\x0d":
+        return ForensicInputType.DISK_IMAGE
+
+    # PCAP magic: 0xa1b2c3d4 or 0xd4c3b2a1 (swapped)
+    if header[:4] in (b"\xa1\xb2\xc3\xd4", b"\xd4\xc3\xb2\xa1"):
+        return ForensicInputType.PCAP
+
+    # PCAPNG magic: 0x0a0d0d0a (Section Header Block)
+    if header[:4] == b"\x0a\x0d\x0d\x0a":
+        return ForensicInputType.PCAP
+
+    # VxWorks ESTFBINR signature
+    if header[:8] == b"ESTFBINR":
+        return ForensicInputType.FIRMWARE
+
+    # ELF binary
+    if header[:4] == b"\x7fELF":
+        return ForensicInputType.FIRMWARE
+
+    # VMDK sparse header: "KDMV"
+    if header[:4] == b"KDMV":
+        return ForensicInputType.DISK_IMAGE
+
+    return ForensicInputType.UNKNOWN

--- a/peat/forensic/firmware.py
+++ b/peat/forensic/firmware.py
@@ -1,0 +1,373 @@
+"""
+Firmware binary analysis and extraction for ICS/SCADA devices.
+
+Scans firmware blobs for known magic signatures (VxWorks ESTFBINR,
+SquashFS, JFFS2, CramFS, ELF) and extracts embedded filesystems
+or configuration data.
+
+@decision: Implements magic byte carving in pure Python rather than
+shelling out to binwalk. This keeps the dependency footprint small and
+avoids binwalk's GPL-3.0 license complications for downstream users.
+The carving logic is intentionally simple — it finds known signatures
+and extracts/decompresses the payload. For complex firmware with
+nested layers, users should use binwalk separately and then feed
+the extracted artifacts to `peat forensic` or `peat parse`.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import struct
+import zlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from peat import config, log
+
+
+# Magic byte signatures for embedded filesystems and formats
+SIGNATURES: dict[str, bytes] = {
+    "vxworks_estfbinr": b"ESTFBINR",
+    "squashfs_le": b"hsqs",
+    "squashfs_be": b"sqsh",
+    "cramfs": b"\x45\x3d\xcd\x28",
+    "jffs2_le": b"\x85\x19",
+    "jffs2_be": b"\x19\x85",
+    "elf": b"\x7fELF",
+    "gzip": b"\x1f\x8b",
+    "zlib_default": b"\x78\x9c",
+    "zlib_best": b"\x78\x01",
+    "zlib_no_compression": b"\x78\x01",
+    "uimage": b"\x27\x05\x19\x56",  # U-Boot image header
+    "cpio_newc": b"070701",
+    "cpio_crc": b"070702",
+}
+
+
+@dataclass
+class FirmwareRegion:
+    """A detected region within a firmware binary."""
+
+    signature_type: str
+    offset: int
+    size: int  # 0 if unknown
+    description: str
+    extracted_path: str = ""  # Path where extracted content was saved
+    content_preview: str = ""  # First few bytes as hex for identification
+
+
+@dataclass
+class FirmwareAnalysisResult:
+    """Results from analyzing a firmware binary."""
+
+    firmware_path: str
+    file_size: int
+    regions: list[FirmwareRegion] = field(default_factory=list)
+    extracted_files: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "firmware_analysis": {
+                "firmware_path": self.firmware_path,
+                "file_size": self.file_size,
+                "regions_found": len(self.regions),
+                "regions": [
+                    {
+                        "type": r.signature_type,
+                        "offset": r.offset,
+                        "size": r.size,
+                        "description": r.description,
+                        "extracted_path": r.extracted_path,
+                        "content_preview": r.content_preview,
+                    }
+                    for r in self.regions
+                ],
+                "extracted_files": self.extracted_files,
+                "errors": self.errors,
+            }
+        }
+
+
+def analyze_firmware(
+    firmware_path: Path,
+    output_dir: Path | None = None,
+    extract: bool = True,
+) -> FirmwareAnalysisResult:
+    """
+    Analyze a firmware binary for embedded filesystems and data.
+
+    Scans the binary for known magic signatures and attempts to extract
+    embedded content (compressed payloads, filesystems, ELF binaries).
+
+    Args:
+        firmware_path: Path to the firmware binary.
+        output_dir: Directory to save extracted content.
+        extract: Whether to extract found regions to disk.
+
+    Returns:
+        FirmwareAnalysisResult with found regions and extraction results.
+    """
+    result = FirmwareAnalysisResult(
+        firmware_path=str(firmware_path),
+        file_size=firmware_path.stat().st_size,
+    )
+
+    if output_dir is None and config.RUN_DIR:
+        output_dir = config.RUN_DIR / "firmware_extracted"
+    if output_dir:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    log.info(f"Scanning firmware binary: {firmware_path.name} ({result.file_size:,} bytes)")
+
+    try:
+        data = firmware_path.read_bytes()
+    except OSError as e:
+        error_msg = f"Failed to read firmware: {e}"
+        log.error(error_msg)
+        result.errors.append(error_msg)
+        return result
+
+    # Scan for all known signatures
+    for sig_name, sig_bytes in SIGNATURES.items():
+        offset = 0
+        while True:
+            idx = data.find(sig_bytes, offset)
+            if idx == -1:
+                break
+
+            region = FirmwareRegion(
+                signature_type=sig_name,
+                offset=idx,
+                size=0,
+                description=_describe_signature(sig_name, data, idx),
+                content_preview=data[idx : idx + 16].hex(),
+            )
+
+            log.info(f"Found {sig_name} signature at offset 0x{idx:08x}: {region.description}")
+            result.regions.append(region)
+
+            # Try to extract this region
+            if extract and output_dir:
+                _extract_region(data, region, output_dir, result)
+
+            # Advance past this signature to find more
+            offset = idx + len(sig_bytes)
+
+    log.info(
+        f"Firmware scan complete: found {len(result.regions)} regions, "
+        f"extracted {len(result.extracted_files)} files"
+    )
+
+    # Write results
+    if output_dir:
+        results_path = output_dir / "firmware-analysis-results.json"
+        try:
+            results_path.write_text(json.dumps(result.to_dict(), indent=4))
+        except OSError as e:
+            log.warning(f"Failed to write results: {e}")
+
+    return result
+
+
+def _describe_signature(sig_name: str, data: bytes, offset: int) -> str:
+    """Generate a human-readable description for a detected signature."""
+    descriptions = {
+        "vxworks_estfbinr": "VxWorks ESTFBINR firmware container",
+        "squashfs_le": "SquashFS filesystem (little-endian)",
+        "squashfs_be": "SquashFS filesystem (big-endian)",
+        "cramfs": "CramFS compressed ROM filesystem",
+        "jffs2_le": "JFFS2 filesystem (little-endian)",
+        "jffs2_be": "JFFS2 filesystem (big-endian)",
+        "elf": "ELF executable/library",
+        "gzip": "gzip compressed data",
+        "zlib_default": "zlib compressed data (default compression)",
+        "zlib_best": "zlib compressed data (best compression)",
+        "zlib_no_compression": "zlib compressed data (no compression)",
+        "uimage": "U-Boot firmware image",
+        "cpio_newc": "CPIO archive (newc format)",
+        "cpio_crc": "CPIO archive (CRC format)",
+    }
+
+    desc = descriptions.get(sig_name, f"Unknown signature: {sig_name}")
+
+    # Add ELF details if available
+    if sig_name == "elf" and offset + 20 <= len(data):
+        ei_class = data[offset + 4]
+        ei_data = data[offset + 5]
+        bits = {1: "32-bit", 2: "64-bit"}.get(ei_class, "unknown")
+        endian = {1: "little-endian", 2: "big-endian"}.get(ei_data, "unknown")
+        desc = f"ELF executable ({bits}, {endian})"
+
+    return desc
+
+
+def _extract_region(
+    data: bytes,
+    region: FirmwareRegion,
+    output_dir: Path,
+    result: FirmwareAnalysisResult,
+) -> None:
+    """Attempt to extract content from a detected firmware region."""
+    offset = region.offset
+
+    try:
+        if region.signature_type == "vxworks_estfbinr":
+            _extract_vxworks(data, offset, output_dir, region, result)
+        elif region.signature_type in ("gzip", "zlib_default", "zlib_best"):
+            _extract_compressed(data, offset, region.signature_type, output_dir, region, result)
+        elif region.signature_type == "elf":
+            _extract_elf(data, offset, output_dir, region, result)
+        elif region.signature_type in ("squashfs_le", "squashfs_be"):
+            _extract_raw_region(data, offset, output_dir, region, result, "squashfs")
+        elif region.signature_type == "cramfs":
+            _extract_raw_region(data, offset, output_dir, region, result, "cramfs")
+    except Exception as e:
+        error_msg = f"Extraction failed for {region.signature_type} at 0x{offset:08x}: {e}"
+        log.warning(error_msg)
+        result.errors.append(error_msg)
+
+
+def _extract_vxworks(
+    data: bytes,
+    offset: int,
+    output_dir: Path,
+    region: FirmwareRegion,
+    result: FirmwareAnalysisResult,
+) -> None:
+    """
+    Extract VxWorks ESTFBINR firmware container.
+
+    ESTFBINR format: 8-byte magic, then typically zlib-compressed payload.
+    """
+    payload_start = offset + 8  # Skip "ESTFBINR"
+
+    # Try to decompress the payload
+    try:
+        decompressed = zlib.decompress(data[payload_start:])
+        out_path = output_dir / f"vxworks_0x{offset:08x}_decompressed.bin"
+        out_path.write_bytes(decompressed)
+        region.size = len(decompressed)
+        region.extracted_path = str(out_path)
+        result.extracted_files.append(str(out_path))
+        log.info(f"Extracted VxWorks payload: {len(decompressed):,} bytes → {out_path.name}")
+    except zlib.error:
+        # Not zlib compressed — save raw payload
+        # Estimate size: look for next known signature or use remaining data
+        end = _find_next_signature(data, payload_start + 256)
+        if end == -1:
+            end = len(data)
+        raw = data[payload_start:end]
+        out_path = output_dir / f"vxworks_0x{offset:08x}_raw.bin"
+        out_path.write_bytes(raw)
+        region.size = len(raw)
+        region.extracted_path = str(out_path)
+        result.extracted_files.append(str(out_path))
+        log.info(f"Saved raw VxWorks payload: {len(raw):,} bytes → {out_path.name}")
+
+
+def _extract_compressed(
+    data: bytes,
+    offset: int,
+    sig_type: str,
+    output_dir: Path,
+    region: FirmwareRegion,
+    result: FirmwareAnalysisResult,
+) -> None:
+    """Extract zlib or gzip compressed data."""
+    try:
+        if sig_type == "gzip":
+            decompressed = zlib.decompress(data[offset:], zlib.MAX_WBITS | 16)
+        else:
+            decompressed = zlib.decompress(data[offset:])
+
+        out_path = output_dir / f"{sig_type}_0x{offset:08x}_decompressed.bin"
+        out_path.write_bytes(decompressed)
+        region.size = len(decompressed)
+        region.extracted_path = str(out_path)
+        result.extracted_files.append(str(out_path))
+        log.debug(f"Decompressed {sig_type}: {len(decompressed):,} bytes → {out_path.name}")
+    except zlib.error as e:
+        log.trace(f"Decompression failed for {sig_type} at 0x{offset:08x}: {e}")
+
+
+def _extract_elf(
+    data: bytes,
+    offset: int,
+    output_dir: Path,
+    region: FirmwareRegion,
+    result: FirmwareAnalysisResult,
+) -> None:
+    """Extract an ELF binary from the firmware."""
+    # ELF header contains the file size information
+    if offset + 64 > len(data):
+        return
+
+    ei_class = data[offset + 4]
+
+    if ei_class == 1:  # 32-bit
+        if offset + 52 > len(data):
+            return
+        # e_shoff (section header offset) + e_shnum * e_shentsize gives approximate end
+        e_shoff = struct.unpack_from("<I", data, offset + 32)[0]
+        e_shnum = struct.unpack_from("<H", data, offset + 48)[0]
+        e_shentsize = struct.unpack_from("<H", data, offset + 46)[0]
+        elf_size = e_shoff + (e_shnum * e_shentsize)
+    elif ei_class == 2:  # 64-bit
+        if offset + 64 > len(data):
+            return
+        e_shoff = struct.unpack_from("<Q", data, offset + 40)[0]
+        e_shnum = struct.unpack_from("<H", data, offset + 60)[0]
+        e_shentsize = struct.unpack_from("<H", data, offset + 58)[0]
+        elf_size = e_shoff + (e_shnum * e_shentsize)
+    else:
+        return
+
+    if elf_size <= 0 or elf_size > len(data) - offset:
+        elf_size = min(len(data) - offset, 10 * 1024 * 1024)  # Cap at 10MB
+
+    elf_data = data[offset : offset + elf_size]
+    out_path = output_dir / f"elf_0x{offset:08x}.bin"
+    out_path.write_bytes(elf_data)
+    region.size = elf_size
+    region.extracted_path = str(out_path)
+    result.extracted_files.append(str(out_path))
+    log.debug(f"Extracted ELF: {elf_size:,} bytes → {out_path.name}")
+
+
+def _extract_raw_region(
+    data: bytes,
+    offset: int,
+    output_dir: Path,
+    region: FirmwareRegion,
+    result: FirmwareAnalysisResult,
+    name: str,
+) -> None:
+    """
+    Extract a raw filesystem region (SquashFS, CramFS, etc.).
+
+    Saves from the signature to the next known signature or end of file.
+    """
+    end = _find_next_signature(data, offset + 256)
+    if end == -1:
+        end = len(data)
+
+    region_data = data[offset:end]
+    out_path = output_dir / f"{name}_0x{offset:08x}.img"
+    out_path.write_bytes(region_data)
+    region.size = len(region_data)
+    region.extracted_path = str(out_path)
+    result.extracted_files.append(str(out_path))
+    log.debug(f"Extracted {name}: {len(region_data):,} bytes → {out_path.name}")
+
+
+def _find_next_signature(data: bytes, start: int) -> int:
+    """Find the offset of the next known signature after 'start'."""
+    next_sig = -1
+    for sig_bytes in SIGNATURES.values():
+        idx = data.find(sig_bytes, start)
+        if idx != -1 and (next_sig == -1 or idx < next_sig):
+            next_sig = idx
+    return next_sig

--- a/peat/forensic/image.py
+++ b/peat/forensic/image.py
@@ -1,0 +1,581 @@
+"""
+Forensic disk image analysis via the dissect framework.
+
+Opens forensic disk images (E01, dd/raw, VMDK, VHD/VHDX, QCoW2) and
+virtual-walks their filesystems to extract ICS/SCADA artifacts without
+mounting the image or requiring root privileges.
+
+Uses dissect.target for high-level auto-detection, falling back to
+manual container → volume → filesystem layering for edge cases.
+
+@decision: Uses dissect.target.Target.open() as the primary entry point
+rather than manually composing EWF + Disk + filesystem objects. Target.open
+auto-detects container format, partition scheme, and filesystem type in one
+call. Manual composition is available as a fallback for images that
+Target.open cannot handle (e.g., bare filesystem images without partition
+tables, which are common in embedded ICS device dumps).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import io
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, BinaryIO
+
+from peat import config, log, module_api
+from peat.forensic.integrity import ForensicMetadata
+
+
+@dataclass
+class ExtractedArtifact:
+    """An artifact extracted from a forensic disk image."""
+
+    virtual_path: str  # Path within the image filesystem
+    file_name: str
+    file_size: int
+    matched_module: str  # PEAT device module that matched
+    matched_pattern: str  # Glob pattern that matched
+    content: bytes | None = None  # File content (if extracted to memory)
+    output_path: str = ""  # Path where artifact was saved (if exported)
+
+
+@dataclass
+class ImageAnalysisResult:
+    """Results from analyzing a forensic disk image."""
+
+    image_path: str
+    image_type: str  # e01, dd, vmdk, etc.
+    partitions_found: int = 0
+    filesystem_type: str = ""
+    total_files_scanned: int = 0
+    artifacts: list[ExtractedArtifact] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "image_analysis": {
+                "image_path": self.image_path,
+                "image_type": self.image_type,
+                "partitions_found": self.partitions_found,
+                "filesystem_type": self.filesystem_type,
+                "total_files_scanned": self.total_files_scanned,
+                "artifacts_found": len(self.artifacts),
+                "artifacts": [
+                    {
+                        "virtual_path": a.virtual_path,
+                        "file_name": a.file_name,
+                        "file_size": a.file_size,
+                        "matched_module": a.matched_module,
+                        "matched_pattern": a.matched_pattern,
+                        "output_path": a.output_path,
+                    }
+                    for a in self.artifacts
+                ],
+                "errors": self.errors,
+            }
+        }
+
+
+def _get_ics_file_patterns() -> dict[str, list[str]]:
+    """
+    Collect filename patterns from all registered PEAT device modules.
+
+    Returns:
+        Dict mapping module name → list of glob patterns the module can parse.
+    """
+    patterns: dict[str, list[str]] = {}
+    for mod_cls in module_api.classes:
+        if hasattr(mod_cls, "filename_patterns") and mod_cls.filename_patterns:
+            name = getattr(mod_cls, "name", mod_cls.__name__)
+            patterns[name] = list(mod_cls.filename_patterns)
+    return patterns
+
+
+# Common ICS-related file patterns beyond what device modules define
+_EXTRA_ICS_PATTERNS: dict[str, list[str]] = {
+    "ics_config": [
+        "*.cfg",
+        "*.conf",
+        "*.ini",
+        "*.yaml",
+        "*.yml",
+    ],
+    "ics_project": [
+        "*.l5x",
+        "*.L5X",
+        "*.l5k",
+        "*.L5K",
+        "*.apx",
+        "*.rdb",
+        "*.RDB",
+        "*.wset",
+        "*.tc",
+    ],
+    "ics_firmware": [
+        "*.bin",
+        "*.fw",
+        "*.dmk",
+        "*.rom",
+        "*.hex",
+    ],
+    "ics_log": [
+        "*.cev",
+        "*.ser",
+        "SET_*.TXT",
+        "set_*.txt",
+        "*_events.csv",
+        "*_audit.csv",
+    ],
+}
+
+# Directories commonly excluded during forensic search
+_EXCLUDED_DIRS = {
+    "windows",
+    "system volume information",
+    "$recycle.bin",
+    "recovery",
+    "program files",
+    "program files (x86)",
+    "programdata",
+    "__pycache__",
+    ".git",
+    "node_modules",
+}
+
+
+def analyze_disk_image(
+    image_path: Path,
+    metadata: ForensicMetadata | None = None,
+    output_dir: Path | None = None,
+    extract_artifacts: bool = True,
+    include_extra_patterns: bool = True,
+) -> ImageAnalysisResult:
+    """
+    Analyze a forensic disk image for ICS/SCADA artifacts.
+
+    Opens the image using dissect.target, walks the filesystem(s), and
+    identifies files matching PEAT device module patterns.
+
+    Args:
+        image_path: Path to the disk image file.
+        metadata: Forensic metadata from the integrity module.
+        output_dir: Directory to save extracted artifacts. If None, uses
+                    config.RUN_DIR / "forensic_artifacts".
+        extract_artifacts: Whether to extract matching files to disk.
+        include_extra_patterns: Include common ICS patterns beyond module patterns.
+
+    Returns:
+        ImageAnalysisResult with found artifacts and analysis metadata.
+    """
+    suffix = image_path.suffix.lower()
+    image_type = suffix.lstrip(".")
+    result = ImageAnalysisResult(
+        image_path=str(image_path),
+        image_type=image_type,
+    )
+
+    # Collect patterns to search for
+    patterns = _get_ics_file_patterns()
+    if include_extra_patterns:
+        patterns.update(_EXTRA_ICS_PATTERNS)
+
+    total_patterns = sum(len(v) for v in patterns.values())
+    log.info(
+        f"Searching image for ICS artifacts using {total_patterns} patterns "
+        f"from {len(patterns)} sources"
+    )
+
+    # Set up output directory
+    if output_dir is None and config.RUN_DIR:
+        output_dir = config.RUN_DIR / "forensic_artifacts"
+    if output_dir:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Try high-level Target.open first, fall back to manual approach
+    try:
+        result = _analyze_with_target(image_path, result, patterns, output_dir, extract_artifacts)
+    except Exception as e:
+        log.warning(f"Target.open failed ({e}), trying manual container analysis...")
+        try:
+            result = _analyze_manual(image_path, result, patterns, output_dir, extract_artifacts)
+        except Exception as e2:
+            error_msg = f"Failed to analyze image: {e2}"
+            log.error(error_msg)
+            result.errors.append(error_msg)
+
+    log.info(
+        f"Image analysis complete: scanned {result.total_files_scanned} files, "
+        f"found {len(result.artifacts)} ICS artifacts"
+    )
+
+    # Write analysis results to output
+    if output_dir:
+        results_path = output_dir / "image-analysis-results.json"
+        try:
+            results_path.write_text(json.dumps(result.to_dict(), indent=4))
+            log.debug(f"Analysis results written to: {results_path}")
+        except OSError as e:
+            log.warning(f"Failed to write analysis results: {e}")
+
+    return result
+
+
+def _analyze_with_target(
+    image_path: Path,
+    result: ImageAnalysisResult,
+    patterns: dict[str, list[str]],
+    output_dir: Path | None,
+    extract_artifacts: bool,
+) -> ImageAnalysisResult:
+    """Analyze using dissect.target.Target high-level API."""
+    from dissect.target import Target
+
+    log.info(f"Opening image with dissect Target: {image_path.name}")
+    target = Target.open(image_path)
+
+    # Walk each filesystem the target exposes
+    for fs in target.filesystems:
+        fs_type = type(fs).__name__
+        log.info(f"Walking filesystem: {fs_type}")
+        result.filesystem_type = fs_type
+        result.partitions_found += 1
+
+        _walk_filesystem(
+            fs=fs,
+            result=result,
+            patterns=patterns,
+            output_dir=output_dir,
+            extract_artifacts=extract_artifacts,
+        )
+
+    return result
+
+
+def _analyze_manual(
+    image_path: Path,
+    result: ImageAnalysisResult,
+    patterns: dict[str, list[str]],
+    output_dir: Path | None,
+    extract_artifacts: bool,
+) -> ImageAnalysisResult:
+    """
+    Manual analysis for images that Target.open cannot handle.
+
+    Opens the container directly, enumerates partitions, and mounts
+    filesystems individually.
+    """
+    from dissect.volume.disk import Disk
+
+    fh = _open_container(image_path)
+
+    try:
+        disk = Disk(fh)
+    except Exception:
+        # Might be a bare filesystem image — try filesystems directly
+        log.debug("No partition table found, trying as bare filesystem")
+        fh.seek(0)
+        fs = _try_detect_filesystem(fh)
+        if fs:
+            result.filesystem_type = type(fs).__name__
+            result.partitions_found = 1
+            _walk_filesystem(fs, result, patterns, output_dir, extract_artifacts)
+        else:
+            result.errors.append("Could not detect filesystem in image")
+        return result
+
+    # Iterate partitions
+    for i, partition in enumerate(disk.partitions):
+        log.info(f"Analyzing partition {i}")
+        result.partitions_found += 1
+
+        try:
+            part_fh = partition.open()
+            fs = _try_detect_filesystem(part_fh)
+            if fs:
+                result.filesystem_type = type(fs).__name__
+                _walk_filesystem(fs, result, patterns, output_dir, extract_artifacts)
+            else:
+                log.debug(f"Partition {i}: unknown filesystem, skipping")
+        except Exception as e:
+            error_msg = f"Partition {i} analysis failed: {e}"
+            log.warning(error_msg)
+            result.errors.append(error_msg)
+
+    return result
+
+
+def _open_container(path: Path) -> BinaryIO:
+    """
+    Open a forensic container file and return a seekable binary stream.
+
+    Handles E01, VMDK, VHD, and raw/dd images.
+    """
+    suffix = path.suffix.lower()
+
+    if suffix == ".e01":
+        from dissect.evidence.ewf import EWF
+
+        log.debug("Opening E01 container")
+        return EWF(path)
+
+    if suffix in (".vmdk",):
+        from dissect.hypervisor.vmdk import VMDK
+
+        log.debug("Opening VMDK container")
+        vmdk = VMDK(path)
+        return vmdk.open()
+
+    if suffix in (".vhd", ".vhdx"):
+        from dissect.hypervisor.vhd import VHD
+
+        log.debug("Opening VHD/VHDX container")
+        vhd = VHD(path)
+        return vhd.open()
+
+    if suffix in (".qcow2",):
+        from dissect.hypervisor.qcow2 import QCow2
+
+        log.debug("Opening QCoW2 container")
+        qcow2 = QCow2(path.open("rb"))
+        return qcow2.open()
+
+    # Raw/dd — just open the file directly
+    log.debug("Opening raw/dd image")
+    return path.open("rb")
+
+
+def _try_detect_filesystem(fh: BinaryIO) -> Any:
+    """
+    Try to detect and open a filesystem from a binary stream.
+
+    Attempts each supported filesystem type in order of likelihood
+    for ICS environments.
+    """
+    fs_types = [
+        ("NTFS", "dissect.ntfs", "NTFS"),
+        ("ExtFS", "dissect.extfs", "ExtFS"),
+        ("FAT", "dissect.fat", "FAT"),
+        ("QnxFs", "dissect.qnxfs", "QnxFs"),
+        ("SquashFS", "dissect.squashfs", "SquashFS"),
+        ("JFFS2", "dissect.jffs", "JFFS2"),
+        ("CramFS", "dissect.cramfs", "CramFS"),
+        ("XFS", "dissect.xfs", "XFS"),
+        ("BtrFS", "dissect.btrfs", "BtrFS"),
+        ("FFS", "dissect.ffs", "FFS"),
+    ]
+
+    for name, module_path, class_name in fs_types:
+        try:
+            import importlib
+
+            mod = importlib.import_module(module_path)
+            fs_class = getattr(mod, class_name)
+            fh.seek(0)
+            fs = fs_class(fh)
+            log.debug(f"Detected filesystem: {name}")
+            return fs
+        except Exception:
+            continue
+
+    return None
+
+
+def _walk_filesystem(
+    fs: Any,
+    result: ImageAnalysisResult,
+    patterns: dict[str, list[str]],
+    output_dir: Path | None,
+    extract_artifacts: bool,
+) -> None:
+    """
+    Walk a dissect filesystem and search for ICS artifacts.
+
+    Uses the filesystem's walk/iterdir methods to traverse directories
+    and match files against known ICS patterns.
+    """
+    # dissect filesystems expose different APIs depending on the type
+    # Target filesystems have .path() and .walk()
+    # Raw filesystem objects have .get() and manual iteration
+
+    if hasattr(fs, "path"):
+        # dissect.target Filesystem or LayerFilesystem
+        _walk_target_fs(fs, result, patterns, output_dir, extract_artifacts)
+    elif hasattr(fs, "get"):
+        # Raw dissect filesystem (NTFS, ExtFS, etc.)
+        _walk_raw_fs(fs, result, patterns, output_dir, extract_artifacts)
+    else:
+        log.warning(f"Unknown filesystem interface: {type(fs).__name__}")
+
+
+def _walk_target_fs(
+    fs: Any,
+    result: ImageAnalysisResult,
+    patterns: dict[str, list[str]],
+    output_dir: Path | None,
+    extract_artifacts: bool,
+) -> None:
+    """Walk a dissect.target Filesystem using its path/walk API."""
+    try:
+        for dirpath, dirnames, filenames in fs.walk("/"):
+            # Skip excluded directories
+            dir_name = dirpath.rsplit("/", 1)[-1].lower() if "/" in dirpath else dirpath.lower()
+            if dir_name in _EXCLUDED_DIRS:
+                continue
+
+            for filename in filenames:
+                result.total_files_scanned += 1
+                virtual_path = f"{dirpath}/{filename}" if dirpath != "/" else f"/{filename}"
+
+                _check_and_extract(
+                    fs, virtual_path, filename, result, patterns,
+                    output_dir, extract_artifacts,
+                )
+    except Exception as e:
+        error_msg = f"Filesystem walk error: {e}"
+        log.warning(error_msg)
+        result.errors.append(error_msg)
+
+
+def _walk_raw_fs(
+    fs: Any,
+    result: ImageAnalysisResult,
+    patterns: dict[str, list[str]],
+    output_dir: Path | None,
+    extract_artifacts: bool,
+) -> None:
+    """Walk a raw dissect filesystem using its native get/iterdir API."""
+    try:
+        root = fs.get("/")
+        _walk_raw_entry(root, "/", fs, result, patterns, output_dir, extract_artifacts)
+    except Exception as e:
+        error_msg = f"Raw filesystem walk error: {e}"
+        log.warning(error_msg)
+        result.errors.append(error_msg)
+
+
+def _walk_raw_entry(
+    entry: Any,
+    current_path: str,
+    fs: Any,
+    result: ImageAnalysisResult,
+    patterns: dict[str, list[str]],
+    output_dir: Path | None,
+    extract_artifacts: bool,
+) -> None:
+    """Recursively walk a raw filesystem entry."""
+    try:
+        if hasattr(entry, "is_dir") and entry.is_dir():
+            dir_name = current_path.rsplit("/", 1)[-1].lower()
+            if dir_name in _EXCLUDED_DIRS:
+                return
+
+            if hasattr(entry, "iterdir"):
+                for child in entry.iterdir():
+                    child_name = getattr(child, "name", str(child))
+                    child_path = f"{current_path}/{child_name}".replace("//", "/")
+                    _walk_raw_entry(
+                        child, child_path, fs, result, patterns,
+                        output_dir, extract_artifacts,
+                    )
+        elif hasattr(entry, "is_file") and entry.is_file():
+            result.total_files_scanned += 1
+            filename = current_path.rsplit("/", 1)[-1]
+            _check_and_extract(
+                fs, current_path, filename, result, patterns,
+                output_dir, extract_artifacts,
+            )
+    except Exception as e:
+        log.trace(f"Error walking {current_path}: {e}")
+
+
+def _check_and_extract(
+    fs: Any,
+    virtual_path: str,
+    filename: str,
+    result: ImageAnalysisResult,
+    patterns: dict[str, list[str]],
+    output_dir: Path | None,
+    extract_artifacts: bool,
+) -> None:
+    """Check if a file matches any ICS pattern and optionally extract it."""
+    for source_name, pattern_list in patterns.items():
+        for pattern in pattern_list:
+            if fnmatch.fnmatch(filename, pattern) or fnmatch.fnmatch(filename.lower(), pattern.lower()):
+                log.info(f"Found ICS artifact: {virtual_path} (matched: {source_name}/{pattern})")
+
+                try:
+                    file_size = _get_file_size(fs, virtual_path)
+                except Exception:
+                    file_size = 0
+
+                artifact = ExtractedArtifact(
+                    virtual_path=virtual_path,
+                    file_name=filename,
+                    file_size=file_size,
+                    matched_module=source_name,
+                    matched_pattern=pattern,
+                )
+
+                # Extract to output directory
+                if extract_artifacts and output_dir:
+                    artifact = _extract_artifact(fs, virtual_path, artifact, output_dir)
+
+                result.artifacts.append(artifact)
+                return  # File matched, no need to check more patterns
+
+
+def _get_file_size(fs: Any, virtual_path: str) -> int:
+    """Get file size from a dissect filesystem."""
+    if hasattr(fs, "path"):
+        # Target filesystem
+        entry = fs.path(virtual_path)
+        if hasattr(entry, "stat"):
+            return entry.stat().st_size
+    elif hasattr(fs, "get"):
+        entry = fs.get(virtual_path)
+        if hasattr(entry, "size"):
+            return entry.size
+    return 0
+
+
+def _extract_artifact(
+    fs: Any,
+    virtual_path: str,
+    artifact: ExtractedArtifact,
+    output_dir: Path,
+) -> ExtractedArtifact:
+    """Extract a file from the forensic image to the output directory."""
+    # Sanitize the virtual path for use as a local path
+    safe_path = virtual_path.lstrip("/").replace("\\", "/")
+    dest = output_dir / safe_path
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        if hasattr(fs, "path"):
+            # Target filesystem
+            entry = fs.path(virtual_path)
+            with entry.open("rb") as src:
+                content = src.read()
+        elif hasattr(fs, "get"):
+            entry = fs.get(virtual_path)
+            if hasattr(entry, "open"):
+                with entry.open("rb") as src:
+                    content = src.read()
+            else:
+                content = entry.read()
+        else:
+            log.warning(f"Cannot read from filesystem type: {type(fs).__name__}")
+            return artifact
+
+        dest.write_bytes(content)
+        artifact.output_path = str(dest)
+        artifact.file_size = len(content)
+        log.debug(f"Extracted: {virtual_path} → {dest} ({len(content):,} bytes)")
+
+    except Exception as e:
+        log.warning(f"Failed to extract {virtual_path}: {e}")
+
+    return artifact

--- a/peat/forensic/integrity.py
+++ b/peat/forensic/integrity.py
@@ -1,0 +1,189 @@
+"""
+Forensic integrity module — hashing, chain of custody, and read-only enforcement.
+
+Provides cryptographic hashing for evidence files, chain-of-custody metadata
+generation, and utilities to ensure all forensic operations are read-only.
+
+@decision: Uses streaming SHA-256 for hashing rather than loading entire files
+into memory. ICS disk images and PCAPs can be multi-gigabyte; streaming with
+a 64KB buffer keeps memory usage constant regardless of file size.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, BinaryIO
+
+from peat import log
+
+
+@dataclass
+class ForensicMetadata:
+    """
+    Chain-of-custody metadata for a forensic artifact.
+
+    Captures the cryptographic hash, file properties, and processing
+    timestamps needed to establish evidence integrity.
+    """
+
+    file_path: str
+    file_name: str
+    file_size: int
+    sha256: str
+    md5: str
+    ingest_time: str  # ISO 8601 UTC
+    peat_version: str = ""
+    notes: str = ""
+    original_modified_time: str = ""  # ISO 8601 UTC
+    additional_hashes: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Export metadata as a dictionary for JSON serialization."""
+        result = {
+            "forensic_integrity": {
+                "file_path": self.file_path,
+                "file_name": self.file_name,
+                "file_size": self.file_size,
+                "hashes": {
+                    "sha256": self.sha256,
+                    "md5": self.md5,
+                    **self.additional_hashes,
+                },
+                "ingest_time_utc": self.ingest_time,
+                "original_modified_time_utc": self.original_modified_time,
+                "peat_version": self.peat_version,
+            }
+        }
+        if self.notes:
+            result["forensic_integrity"]["notes"] = self.notes
+        return result
+
+
+# 64 KB read buffer for streaming hash computation
+_HASH_BUFFER_SIZE = 65536
+
+
+def compute_hashes(path: Path) -> tuple[str, str]:
+    """
+    Compute SHA-256 and MD5 hashes of a file using streaming reads.
+
+    Args:
+        path: Path to the file to hash.
+
+    Returns:
+        Tuple of (sha256_hex, md5_hex).
+
+    Raises:
+        OSError: If the file cannot be read.
+    """
+    sha256 = hashlib.sha256()
+    md5 = hashlib.md5()  # noqa: S324 — MD5 used for identification, not security
+
+    with open(path, "rb") as f:
+        while True:
+            data = f.read(_HASH_BUFFER_SIZE)
+            if not data:
+                break
+            sha256.update(data)
+            md5.update(data)
+
+    return sha256.hexdigest(), md5.hexdigest()
+
+
+def compute_hash_from_stream(stream: BinaryIO, algorithm: str = "sha256") -> str:
+    """
+    Compute a hash from a binary stream without consuming it entirely into memory.
+
+    Args:
+        stream: An open binary stream (must support read()).
+        algorithm: Hash algorithm name (default: sha256).
+
+    Returns:
+        Hex digest string.
+    """
+    h = hashlib.new(algorithm)
+    while True:
+        data = stream.read(_HASH_BUFFER_SIZE)
+        if not data:
+            break
+        h.update(data)
+    return h.hexdigest()
+
+
+def generate_forensic_metadata(path: Path, notes: str = "") -> ForensicMetadata:
+    """
+    Generate complete forensic metadata for an evidence file.
+
+    Computes hashes, captures file properties, and records the ingest timestamp.
+
+    Args:
+        path: Path to the evidence file.
+        notes: Optional analyst notes.
+
+    Returns:
+        ForensicMetadata instance.
+    """
+    from peat import __version__
+
+    log.info(f"Computing forensic hashes for: {path.name}")
+    sha256_hex, md5_hex = compute_hashes(path)
+    log.debug(f"SHA-256: {sha256_hex}")
+    log.debug(f"MD5:     {md5_hex}")
+
+    stat = path.stat()
+    mod_time = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
+    ingest_time = datetime.now(tz=timezone.utc).isoformat()
+
+    return ForensicMetadata(
+        file_path=str(path.resolve()),
+        file_name=path.name,
+        file_size=stat.st_size,
+        sha256=sha256_hex,
+        md5=md5_hex,
+        ingest_time=ingest_time,
+        peat_version=__version__,
+        notes=notes,
+        original_modified_time=mod_time,
+    )
+
+
+def verify_hash(path: Path, expected_sha256: str) -> bool:
+    """
+    Verify a file's SHA-256 hash against an expected value.
+
+    Args:
+        path: Path to the file.
+        expected_sha256: Expected SHA-256 hex digest.
+
+    Returns:
+        True if the hash matches.
+    """
+    sha256_hex, _ = compute_hashes(path)
+    match = sha256_hex == expected_sha256.lower()
+    if not match:
+        log.warning(
+            f"Hash mismatch for {path.name}: "
+            f"expected {expected_sha256}, got {sha256_hex}"
+        )
+    return match
+
+
+def ensure_read_only(path: Path) -> None:
+    """
+    Verify that a file is not writable, and log a warning if it is.
+
+    This is a defensive check — forensic operations should never modify evidence.
+    The actual protection comes from opening files in read-only mode.
+
+    Args:
+        path: Path to check.
+    """
+    if os.access(path, os.W_OK):
+        log.warning(
+            f"Evidence file is writable: {path}. "
+            f"Consider setting read-only permissions before analysis."
+        )

--- a/peat/forensic/logs/__init__.py
+++ b/peat/forensic/logs/__init__.py
@@ -1,0 +1,14 @@
+"""
+ICS/SCADA log file parsing — vendor-specific parsers with ECS normalization.
+
+Provides a unified ingestion framework that auto-detects log format and
+normalizes output to Elastic Common Schema (ECS) compliant JSON.
+
+Supported formats:
+  - SEL relay SER (Sequential Events Recorder) logs
+  - Siemens SIPROTEC CSV/text diagnostic exports
+  - GE UR relay Security Audit Logs and IEC 61850 SCL XML
+  - Schneider ClearSCADA Comms logs (TX/RX format)
+  - Rockwell FactoryTalk Alarms and Events CSV exports
+  - OSIsoft PI / AVEVA historian CSV/XML exports
+"""

--- a/peat/forensic/logs/base.py
+++ b/peat/forensic/logs/base.py
@@ -1,0 +1,209 @@
+"""
+Base classes for ICS/SCADA log parsers.
+
+Provides the LogParser abstract base and ParsedLogEntry data class
+that all vendor-specific parsers build upon. Handles common operations
+like timestamp normalization and ECS field mapping.
+
+@decision: Uses a flat ParsedLogEntry dataclass rather than PEAT's
+Event pydantic model directly. This keeps the forensic parsers
+decoupled from the data model — the normalization layer converts
+ParsedLogEntry → Event as a separate step. This allows the forensic
+module to be used standalone for log analysis without requiring
+full PEAT initialization.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+from peat import log
+
+
+@dataclass
+class ParsedLogEntry:
+    """
+    A normalized log entry from any ICS/SCADA source.
+
+    Fields follow the Elastic Common Schema (ECS) naming conventions
+    where applicable.
+    """
+
+    # Core ECS fields
+    timestamp: datetime | None = None  # event.created
+    message: str = ""  # event.message
+    original: str = ""  # event.original (raw line)
+
+    # Source identification
+    source_type: str = ""  # e.g. "sel_ser", "siprotec_csv"
+    source_file: str = ""  # Original filename
+
+    # Event classification (ECS)
+    action: str = ""  # event.action (e.g. "relay_trip", "config_change")
+    category: str = ""  # event.category (e.g. "configuration", "process")
+    severity: str = ""  # event.severity (e.g. "info", "warning", "critical")
+    outcome: str = ""  # event.outcome (e.g. "success", "failure")
+
+    # Device identification
+    device_id: str = ""  # Relay ID, PLC name, etc.
+    device_vendor: str = ""  # e.g. "SEL", "Siemens", "GE"
+    device_model: str = ""  # e.g. "SEL-751", "SIPROTEC 5"
+
+    # Network context (if applicable)
+    source_ip: str = ""
+    destination_ip: str = ""
+    source_port: int = 0
+    destination_port: int = 0
+
+    # Additional structured data
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_ecs_dict(self) -> dict[str, Any]:
+        """Convert to ECS-compliant dictionary for Elasticsearch output."""
+        result: dict[str, Any] = {
+            "event": {
+                "created": self.timestamp.isoformat() if self.timestamp else None,
+                "message": self.message,
+                "original": self.original,
+                "action": self.action,
+                "category": self.category,
+                "severity": self.severity,
+                "outcome": self.outcome,
+                "module": "peat_forensic",
+                "dataset": self.source_type,
+            },
+            "observer": {
+                "vendor": self.device_vendor,
+                "product": self.device_model,
+                "name": self.device_id,
+            },
+        }
+
+        if self.source_ip:
+            result["source"] = {"ip": self.source_ip}
+            if self.source_port:
+                result["source"]["port"] = self.source_port
+        if self.destination_ip:
+            result["destination"] = {"ip": self.destination_ip}
+            if self.destination_port:
+                result["destination"]["port"] = self.destination_port
+
+        # Hash the original line for integrity
+        if self.original:
+            result["event"]["hash"] = hashlib.sha256(
+                self.original.encode("utf-8", errors="replace")
+            ).hexdigest()
+
+        if self.extra:
+            result["extra"] = self.extra
+
+        # Remove empty values
+        result["event"] = {k: v for k, v in result["event"].items() if v}
+        result["observer"] = {k: v for k, v in result["observer"].items() if v}
+
+        return result
+
+
+class LogParser(ABC):
+    """
+    Abstract base class for ICS/SCADA log parsers.
+
+    Subclasses implement detect() and parse() for a specific vendor format.
+    """
+
+    name: str = "unknown"
+    vendor: str = "unknown"
+    description: str = ""
+    file_patterns: list[str] = []  # Glob patterns this parser handles
+
+    @classmethod
+    @abstractmethod
+    def detect(cls, path: Path, sample: str = "") -> bool:
+        """
+        Determine if this parser can handle the given file.
+
+        Args:
+            path: Path to the log file.
+            sample: First ~4KB of the file content for sniffing.
+
+        Returns:
+            True if this parser can handle the file.
+        """
+        ...
+
+    @classmethod
+    @abstractmethod
+    def parse(cls, path: Path) -> list[ParsedLogEntry]:
+        """
+        Parse a log file and return normalized entries.
+
+        Args:
+            path: Path to the log file.
+
+        Returns:
+            List of ParsedLogEntry instances.
+        """
+        ...
+
+    @classmethod
+    def _read_text(cls, path: Path) -> str:
+        """Read a text file with fallback encoding."""
+        for encoding in ("utf-8", "latin-1", "cp1252"):
+            try:
+                return path.read_text(encoding=encoding)
+            except UnicodeDecodeError:
+                continue
+        return path.read_text(encoding="utf-8", errors="replace")
+
+    @classmethod
+    def _read_csv(cls, path: Path) -> list[dict[str, str]]:
+        """Read a CSV file and return list of row dicts."""
+        text = cls._read_text(path)
+        reader = csv.DictReader(io.StringIO(text))
+        return list(reader)
+
+    @classmethod
+    def _parse_timestamp(cls, ts_str: str, formats: list[str] | None = None) -> datetime | None:
+        """
+        Parse a timestamp string trying multiple formats.
+
+        Args:
+            ts_str: Timestamp string to parse.
+            formats: List of strptime format strings to try.
+
+        Returns:
+            Parsed datetime or None if no format matched.
+        """
+        if not ts_str or not ts_str.strip():
+            return None
+
+        ts_str = ts_str.strip()
+
+        default_formats = [
+            "%Y-%m-%d %H:%M:%S.%f",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%dT%H:%M:%S.%f",
+            "%Y-%m-%dT%H:%M:%S",
+            "%m/%d/%Y %H:%M:%S.%f",
+            "%m/%d/%Y %H:%M:%S",
+            "%d/%m/%Y %H:%M:%S",
+            "%Y/%m/%d %H:%M:%S",
+            "%b %d %Y %H:%M:%S",
+            "%d-%b-%Y %H:%M:%S",
+        ]
+
+        for fmt in (formats or default_formats):
+            try:
+                return datetime.strptime(ts_str, fmt)
+            except ValueError:
+                continue
+
+        return None

--- a/peat/forensic/logs/ingest.py
+++ b/peat/forensic/logs/ingest.py
@@ -1,0 +1,143 @@
+"""
+Unified ICS/SCADA log ingestion framework.
+
+Auto-detects log format and dispatches to the appropriate vendor parser.
+Handles single files, directories of logs, and mixed-format collections.
+
+@decision: Parser registration uses a simple list rather than a plugin
+system. The number of ICS log parsers is small and well-defined — the
+overhead of a full plugin registry isn't justified. New parsers are added
+by importing them here and appending to PARSERS.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from peat import config, log
+from peat.forensic.logs.base import LogParser, ParsedLogEntry
+from peat.forensic.logs.schneider_parser import SchneiderCommsParser, SchneiderModiconCSVParser
+from peat.forensic.logs.sel_parser import SELLogParser
+from peat.forensic.logs.siprotec_parser import GenericCSVLogParser, SiprotecLogParser
+
+# Ordered list of parsers — vendor-specific first, generic last
+PARSERS: list[type[LogParser]] = [
+    SELLogParser,
+    SiprotecLogParser,
+    SchneiderCommsParser,
+    SchneiderModiconCSVParser,
+    GenericCSVLogParser,  # Fallback — must be last
+]
+
+
+def ingest_logs(
+    path: Path,
+    output_dir: Path | None = None,
+) -> list[ParsedLogEntry]:
+    """
+    Ingest log files from a path (file or directory).
+
+    Auto-detects the log format and dispatches to the appropriate parser.
+    Results are normalized to ParsedLogEntry and optionally written as
+    ECS-compliant JSON.
+
+    Args:
+        path: Path to a log file or directory of log files.
+        output_dir: Directory to write parsed results. If None, uses
+                    config.RUN_DIR / "forensic_logs".
+
+    Returns:
+        List of all parsed log entries.
+    """
+    if output_dir is None and config.RUN_DIR:
+        output_dir = config.RUN_DIR / "forensic_logs"
+    if output_dir:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    all_entries: list[ParsedLogEntry] = []
+
+    if path.is_file():
+        entries = _ingest_single_file(path)
+        all_entries.extend(entries)
+    elif path.is_dir():
+        log.info(f"Scanning directory for log files: {path}")
+        for child in sorted(path.rglob("*")):
+            if child.is_file() and not child.name.startswith("."):
+                entries = _ingest_single_file(child)
+                all_entries.extend(entries)
+    else:
+        log.error(f"Log path is not a file or directory: {path}")
+
+    log.info(f"Total log entries ingested: {len(all_entries)}")
+
+    # Write results
+    if output_dir and all_entries:
+        _write_results(all_entries, output_dir)
+
+    return all_entries
+
+
+def _ingest_single_file(path: Path) -> list[ParsedLogEntry]:
+    """Detect format and parse a single log file."""
+    # Read sample for detection
+    try:
+        sample = path.read_text(encoding="utf-8", errors="replace")[:4096]
+    except OSError as e:
+        log.warning(f"Cannot read log file {path.name}: {e}")
+        return []
+
+    # Try each parser in order
+    for parser_cls in PARSERS:
+        try:
+            if parser_cls.detect(path, sample):
+                log.info(f"Detected {parser_cls.name} format: {path.name}")
+                entries = parser_cls.parse(path)
+                return entries
+        except Exception as e:
+            log.warning(f"{parser_cls.name} failed on {path.name}: {e}")
+            continue
+
+    log.debug(f"No parser matched: {path.name}")
+    return []
+
+
+def _write_results(entries: list[ParsedLogEntry], output_dir: Path) -> None:
+    """Write parsed log entries as ECS-compliant JSON."""
+    # Summary file
+    summary = {
+        "log_ingestion": {
+            "total_entries": len(entries),
+            "sources": _count_by_field(entries, "source_type"),
+            "vendors": _count_by_field(entries, "device_vendor"),
+            "severities": _count_by_field(entries, "severity"),
+            "categories": _count_by_field(entries, "category"),
+        }
+    }
+
+    summary_path = output_dir / "log-ingestion-summary.json"
+    try:
+        summary_path.write_text(json.dumps(summary, indent=4))
+        log.debug(f"Summary written to: {summary_path}")
+    except OSError as e:
+        log.warning(f"Failed to write summary: {e}")
+
+    # Full entries as NDJSON (newline-delimited JSON) for Elasticsearch bulk import
+    entries_path = output_dir / "parsed-log-entries.ndjson"
+    try:
+        with open(entries_path, "w") as f:
+            for entry in entries:
+                f.write(json.dumps(entry.to_ecs_dict(), default=str) + "\n")
+        log.debug(f"Entries written to: {entries_path} ({len(entries)} lines)")
+    except OSError as e:
+        log.warning(f"Failed to write entries: {e}")
+
+
+def _count_by_field(entries: list[ParsedLogEntry], field: str) -> dict[str, int]:
+    """Count entries by a specific field value."""
+    counts: dict[str, int] = {}
+    for entry in entries:
+        val = getattr(entry, field, "") or "unknown"
+        counts[val] = counts.get(val, 0) + 1
+    return counts

--- a/peat/forensic/logs/schneider_parser.py
+++ b/peat/forensic/logs/schneider_parser.py
@@ -1,0 +1,174 @@
+"""
+Schneider Electric ClearSCADA / Geo SCADA Expert comms log parser.
+
+Parses Comms and I/O log files from ClearSCADA / Geo SCADA Expert systems.
+These logs contain TX (transmitted) and RX (received) SCADA communication
+entries with timestamps, status codes, and channel information.
+
+Log format example:
+    2026-03-15 14:23:45.123 TX 01 03 00 00 00 0A C5 CD
+    2026-03-15 14:23:45.456 RX ACCEPTED 01 03 14 00 64 ...
+
+Also handles Schneider Modicon PLC CSV logs from SD card/flash exports.
+
+@decision: TX/RX delimiter-based parsing rather than fixed-width, because
+ClearSCADA log line widths vary based on payload length. The TX/RX keyword
+is the reliable anchor point for splitting direction from payload data.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+
+from peat import log
+from peat.forensic.logs.base import LogParser, ParsedLogEntry
+
+# ClearSCADA comms log patterns
+_COMMS_LINE_RE = re.compile(
+    r"(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}(?:\.\d+)?)\s+"  # Timestamp
+    r"(TX|RX)\s+"  # Direction
+    r"(ACCEPTED|REJECTED|TIMEOUT|ERROR)?\s*"  # Optional status
+    r"(.*)"  # Payload (hex bytes or message)
+)
+
+# Modicon CSV log patterns (FAT16 format from SD/flash)
+_MODICON_HEADER_INDICATORS = {"timestamp", "tag", "value", "quality", "log_data"}
+
+
+class SchneiderCommsParser(LogParser):
+    """Parser for Schneider ClearSCADA/Geo SCADA comms logs."""
+
+    name = "schneider_comms"
+    vendor = "Schneider Electric"
+    description = "Schneider ClearSCADA/Geo SCADA comms log parser"
+    file_patterns = ["*comms*.log", "*comms*.txt", "*clearscada*.log", "*geoscada*.log"]
+
+    @classmethod
+    def detect(cls, path: Path, sample: str = "") -> bool:
+        if not sample:
+            sample = cls._read_text(path)[:4096]
+
+        # Look for TX/RX patterns characteristic of SCADA comms logs
+        tx_rx_count = len(re.findall(r"\b(TX|RX)\s+(ACCEPTED|REJECTED|TIMEOUT|ERROR|\d)", sample))
+        return tx_rx_count >= 3
+
+    @classmethod
+    def parse(cls, path: Path) -> list[ParsedLogEntry]:
+        text = cls._read_text(path)
+        entries: list[ParsedLogEntry] = []
+        channel_info = ""
+
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            # Extract channel information from header
+            if "channel" in stripped.lower() and ":" in stripped:
+                channel_info = stripped
+                continue
+
+            match = _COMMS_LINE_RE.match(stripped)
+            if not match:
+                continue
+
+            ts_str, direction, status, payload = match.groups()
+            timestamp = cls._parse_timestamp(ts_str)
+            status = (status or "").strip()
+            payload = payload.strip()
+
+            # Determine severity from status
+            if status == "REJECTED":
+                severity = "warning"
+                outcome = "failure"
+            elif status == "TIMEOUT":
+                severity = "warning"
+                outcome = "failure"
+            elif status == "ERROR":
+                severity = "error"
+                outcome = "failure"
+            elif status == "ACCEPTED":
+                severity = "info"
+                outcome = "success"
+            else:
+                severity = "info"
+                outcome = ""
+
+            extra: dict = {"direction": direction, "payload": payload}
+            if status:
+                extra["status"] = status
+            if channel_info:
+                extra["channel"] = channel_info
+
+            entries.append(ParsedLogEntry(
+                timestamp=timestamp,
+                message=f"{direction} {status} {payload}".strip(),
+                original=stripped,
+                source_type="schneider_comms",
+                source_file=path.name,
+                action=f"scada_{direction.lower()}",
+                category="network",
+                severity=severity,
+                outcome=outcome,
+                device_vendor="Schneider Electric",
+                device_model="ClearSCADA",
+                extra=extra,
+            ))
+
+        log.info(f"Parsed {len(entries)} comms entries from Schneider log: {path.name}")
+        return entries
+
+
+class SchneiderModiconCSVParser(LogParser):
+    """Parser for Schneider Modicon PLC CSV logs from flash/SD card."""
+
+    name = "schneider_modicon_csv"
+    vendor = "Schneider Electric"
+    description = "Schneider Modicon PLC CSV log parser (SD/flash exports)"
+    file_patterns = ["LOG_*.CSV", "log_*.csv", "LOG_DATA.CSV"]
+
+    @classmethod
+    def detect(cls, path: Path, sample: str = "") -> bool:
+        if not sample:
+            sample = cls._read_text(path)[:4096]
+
+        # Check for 8.3 filename pattern and CSV content
+        name_match = re.match(r"LOG_?\w*\.CSV", path.name, re.IGNORECASE)
+        if not name_match:
+            return False
+
+        # Should have CSV-like content with timestamps
+        return "," in sample and re.search(r"\d{4}[-/]\d{2}[-/]\d{2}", sample) is not None
+
+    @classmethod
+    def parse(cls, path: Path) -> list[ParsedLogEntry]:
+        rows = cls._read_csv(path)
+        if not rows:
+            return []
+
+        entries: list[ParsedLogEntry] = []
+        for row in rows:
+            # Try to find timestamp in any column
+            timestamp = None
+            for val in row.values():
+                timestamp = cls._parse_timestamp(val)
+                if timestamp:
+                    break
+
+            entries.append(ParsedLogEntry(
+                timestamp=timestamp,
+                message=str(row),
+                original=str(row),
+                source_type="schneider_modicon_csv",
+                source_file=path.name,
+                category="process",
+                severity="info",
+                device_vendor="Schneider Electric",
+                device_model="Modicon",
+                extra={k: v for k, v in row.items() if v},
+            ))
+
+        log.info(f"Parsed {len(entries)} entries from Modicon CSV: {path.name}")
+        return entries

--- a/peat/forensic/logs/sel_parser.py
+++ b/peat/forensic/logs/sel_parser.py
@@ -1,0 +1,189 @@
+"""
+SEL (Schweitzer Engineering Laboratories) relay log parser.
+
+Parses SEL Sequential Events Recorder (SER) logs and CSER (Compressed SER)
+exports. These are fixed-width ASCII text files produced by SEL protective
+relays widely used in the energy sector.
+
+SER format example:
+    Date       Time          Event                Loc
+    03/15/2026 14:23:45.123  RELAY TRIP            001
+    03/15/2026 14:23:45.456  67P1T                 001
+
+@decision: Uses a regex-driven line-by-line parser rather than a full
+finite state machine. SEL SER files have a consistent per-line format
+that doesn't require cross-line state tracking for basic event extraction.
+Multi-line fault reports are grouped by matching consecutive entries with
+identical timestamps (within a tolerance window).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+
+from peat import log
+from peat.forensic.logs.base import LogParser, ParsedLogEntry
+
+# SEL SER line patterns
+# Format: DATE TIME EVENT [LOCATION]
+_SER_LINE_RE = re.compile(
+    r"(\d{2}/\d{2}/\d{4})\s+"  # Date: MM/DD/YYYY
+    r"(\d{2}:\d{2}:\d{2}(?:\.\d+)?)\s+"  # Time: HH:MM:SS[.fff]
+    r"(.+?)(?:\s{2,}(\S+))?\s*$"  # Event text, optional location
+)
+
+# Alternative format with different date order
+_SER_LINE_ALT_RE = re.compile(
+    r"(\d{4}-\d{2}-\d{2})\s+"  # Date: YYYY-MM-DD
+    r"(\d{2}:\d{2}:\d{2}(?:\.\d+)?)\s+"  # Time
+    r"(.+?)(?:\s{2,}(\S+))?\s*$"  # Event text, optional location
+)
+
+# Header detection patterns
+_SER_HEADER_PATTERNS = [
+    re.compile(r"^\s*Date\s+Time\s+Event", re.IGNORECASE),
+    re.compile(r"^\s*SER\s+", re.IGNORECASE),
+    re.compile(r"^\s*Sequential Events Recorder", re.IGNORECASE),
+    re.compile(r"^\s*FID=", re.IGNORECASE),
+    re.compile(r"^\s*BFID=", re.IGNORECASE),
+]
+
+# Known SEL event categories for classification
+_TRIP_KEYWORDS = {"trip", "tripped", "67p", "67g", "67q", "51p", "51g", "50p", "50g", "87"}
+_ALARM_KEYWORDS = {"alarm", "alm", "warning", "warn"}
+_CONFIG_KEYWORDS = {"set", "setting", "config", "enable", "disable", "password"}
+_COMMS_KEYWORDS = {"comm", "communication", "port", "serial", "ethernet", "login", "logout"}
+
+
+class SELLogParser(LogParser):
+    """Parser for SEL relay SER/CSER log files."""
+
+    name = "sel_ser"
+    vendor = "SEL"
+    description = "SEL Sequential Events Recorder (SER) log parser"
+    file_patterns = ["*SER.TXT", "*SER.txt", "*ser.txt", "*CSER.TXT", "*cser.txt"]
+
+    @classmethod
+    def detect(cls, path: Path, sample: str = "") -> bool:
+        if not sample:
+            sample = cls._read_text(path)[:4096]
+
+        # Check for SER header patterns
+        for pattern in _SER_HEADER_PATTERNS:
+            if pattern.search(sample):
+                return True
+
+        # Check for date/event lines
+        lines_with_events = 0
+        for line in sample.splitlines()[:50]:
+            if _SER_LINE_RE.match(line.strip()) or _SER_LINE_ALT_RE.match(line.strip()):
+                lines_with_events += 1
+
+        return lines_with_events >= 3
+
+    @classmethod
+    def parse(cls, path: Path) -> list[ParsedLogEntry]:
+        text = cls._read_text(path)
+        entries: list[ParsedLogEntry] = []
+        device_id = ""
+        device_model = ""
+
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            # Extract device identification from header
+            if stripped.startswith("FID=") or stripped.startswith("BFID="):
+                device_id = _extract_fid(stripped)
+                continue
+
+            if "SEL-" in stripped.upper():
+                model_match = re.search(r"(SEL-\d+\w*)", stripped, re.IGNORECASE)
+                if model_match:
+                    device_model = model_match.group(1).upper()
+                continue
+
+            # Try to parse as an event line
+            entry = _parse_ser_line(stripped, path.name, device_id, device_model)
+            if entry:
+                entries.append(entry)
+
+        log.info(f"Parsed {len(entries)} events from SEL SER log: {path.name}")
+        return entries
+
+
+def _extract_fid(line: str) -> str:
+    """Extract relay FID (Firmware ID) from header line."""
+    match = re.search(r"(?:B?FID)=(\S+)", line)
+    return match.group(1) if match else ""
+
+
+def _parse_ser_line(
+    line: str, source_file: str, device_id: str, device_model: str
+) -> ParsedLogEntry | None:
+    """Parse a single SER event line."""
+    match = _SER_LINE_RE.match(line)
+    date_fmt = "%m/%d/%Y"
+
+    if not match:
+        match = _SER_LINE_ALT_RE.match(line)
+        date_fmt = "%Y-%m-%d"
+
+    if not match:
+        return None
+
+    date_str, time_str, event_text, location = match.groups()
+    event_text = event_text.strip()
+
+    # Parse timestamp
+    ts_str = f"{date_str} {time_str}"
+    if "." in time_str:
+        ts_fmt = f"{date_fmt} %H:%M:%S.%f"
+    else:
+        ts_fmt = f"{date_fmt} %H:%M:%S"
+
+    try:
+        timestamp = datetime.strptime(ts_str, ts_fmt)
+    except ValueError:
+        timestamp = None
+
+    # Classify the event
+    action, category, severity = _classify_sel_event(event_text)
+
+    extra: dict = {}
+    if location:
+        extra["location"] = location
+
+    return ParsedLogEntry(
+        timestamp=timestamp,
+        message=event_text,
+        original=line,
+        source_type="sel_ser",
+        source_file=source_file,
+        action=action,
+        category=category,
+        severity=severity,
+        device_id=device_id,
+        device_vendor="SEL",
+        device_model=device_model,
+        extra=extra,
+    )
+
+
+def _classify_sel_event(event_text: str) -> tuple[str, str, str]:
+    """Classify a SEL event into action, category, and severity."""
+    lower = event_text.lower()
+
+    if any(kw in lower for kw in _TRIP_KEYWORDS):
+        return "relay_trip", "process", "critical"
+    if any(kw in lower for kw in _ALARM_KEYWORDS):
+        return "alarm", "process", "warning"
+    if any(kw in lower for kw in _CONFIG_KEYWORDS):
+        return "config_change", "configuration", "info"
+    if any(kw in lower for kw in _COMMS_KEYWORDS):
+        return "communication", "network", "info"
+
+    return "event", "process", "info"

--- a/peat/forensic/logs/siprotec_parser.py
+++ b/peat/forensic/logs/siprotec_parser.py
@@ -1,0 +1,191 @@
+"""
+Siemens SIPROTEC relay diagnostic log parser.
+
+Parses CSV/text diagnostic exports from DIGSI 5 for SIPROTEC 5 relays.
+These contain device diagnosis events, fault records, and security audit entries.
+
+CSV format example:
+    Timestamp,Event ID,Description,Severity
+    2026-03-15 14:23:45,1001,Config download started,Info
+    2026-03-15 14:24:12,1002,Config download complete,Info
+
+@decision: Focuses on CSV exports rather than binary SIPROTEC formats.
+Binary diagnostic logs require proprietary Siemens decoders. CSV exports
+from DIGSI 5 cover the majority of forensic use cases and are parseable
+with standard Python CSV tools.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+from datetime import datetime
+from pathlib import Path
+
+from peat import log
+from peat.forensic.logs.base import LogParser, ParsedLogEntry
+
+# Column name patterns for auto-detection
+_TIMESTAMP_COLS = {"timestamp", "time", "date", "datetime", "date/time", "event time"}
+_EVENT_COLS = {"event", "event id", "eventid", "id", "event_id", "code"}
+_DESC_COLS = {"description", "desc", "message", "text", "event text", "information"}
+_SEVERITY_COLS = {"severity", "level", "priority", "class", "category"}
+
+
+class SiprotecLogParser(LogParser):
+    """Parser for Siemens SIPROTEC CSV diagnostic exports."""
+
+    name = "siprotec_csv"
+    vendor = "Siemens"
+    description = "Siemens SIPROTEC relay diagnostic CSV parser"
+    file_patterns = ["*SIPROTEC*.csv", "*siprotec*.csv", "*DIGSI*.csv", "*digsi*.csv"]
+
+    @classmethod
+    def detect(cls, path: Path, sample: str = "") -> bool:
+        if not sample:
+            sample = cls._read_text(path)[:4096]
+
+        lower = sample.lower()
+
+        # Check for SIPROTEC/DIGSI indicators
+        if "siprotec" in lower or "digsi" in lower:
+            return True
+
+        # Check for CSV with expected column names
+        first_line = sample.split("\n", 1)[0].lower()
+        siprotec_indicators = {"event id", "fault record", "device diagnosis", "siemens"}
+        return any(indicator in first_line for indicator in siprotec_indicators)
+
+    @classmethod
+    def parse(cls, path: Path) -> list[ParsedLogEntry]:
+        rows = cls._read_csv(path)
+        if not rows:
+            return []
+
+        # Auto-detect column mappings
+        headers = {k.lower().strip(): k for k in rows[0].keys()}
+        ts_col = _find_column(headers, _TIMESTAMP_COLS)
+        event_col = _find_column(headers, _EVENT_COLS)
+        desc_col = _find_column(headers, _DESC_COLS)
+        sev_col = _find_column(headers, _SEVERITY_COLS)
+
+        entries: list[ParsedLogEntry] = []
+        for row in rows:
+            ts_str = row.get(ts_col, "") if ts_col else ""
+            timestamp = cls._parse_timestamp(ts_str)
+
+            event_id = row.get(event_col, "") if event_col else ""
+            description = row.get(desc_col, "") if desc_col else ""
+            severity_raw = row.get(sev_col, "") if sev_col else ""
+
+            severity = _normalize_severity(severity_raw)
+            category = _classify_siprotec_event(description, event_id)
+
+            entries.append(ParsedLogEntry(
+                timestamp=timestamp,
+                message=description or event_id,
+                original=str(row),
+                source_type="siprotec_csv",
+                source_file=path.name,
+                action=event_id,
+                category=category,
+                severity=severity,
+                device_vendor="Siemens",
+                device_model="SIPROTEC",
+                extra={k: v for k, v in row.items() if v},
+            ))
+
+        log.info(f"Parsed {len(entries)} events from SIPROTEC log: {path.name}")
+        return entries
+
+
+class GenericCSVLogParser(LogParser):
+    """
+    Generic CSV log parser for ICS devices.
+
+    Handles any CSV file with timestamp and event/description columns.
+    Acts as a fallback when no vendor-specific parser matches.
+    """
+
+    name = "generic_csv"
+    vendor = "unknown"
+    description = "Generic CSV log parser for ICS/SCADA devices"
+    file_patterns = ["*.csv"]
+
+    @classmethod
+    def detect(cls, path: Path, sample: str = "") -> bool:
+        if not sample:
+            sample = cls._read_text(path)[:4096]
+
+        # Must look like CSV with a header row containing time-related column
+        first_line = sample.split("\n", 1)[0].lower()
+        return any(ts in first_line for ts in _TIMESTAMP_COLS) and "," in first_line
+
+    @classmethod
+    def parse(cls, path: Path) -> list[ParsedLogEntry]:
+        rows = cls._read_csv(path)
+        if not rows:
+            return []
+
+        headers = {k.lower().strip(): k for k in rows[0].keys()}
+        ts_col = _find_column(headers, _TIMESTAMP_COLS)
+        desc_col = _find_column(headers, _DESC_COLS)
+        sev_col = _find_column(headers, _SEVERITY_COLS)
+
+        entries: list[ParsedLogEntry] = []
+        for row in rows:
+            ts_str = row.get(ts_col, "") if ts_col else ""
+            timestamp = cls._parse_timestamp(ts_str)
+            description = row.get(desc_col, "") if desc_col else str(row)
+
+            entries.append(ParsedLogEntry(
+                timestamp=timestamp,
+                message=description,
+                original=str(row),
+                source_type="generic_csv",
+                source_file=path.name,
+                severity=_normalize_severity(row.get(sev_col, "")) if sev_col else "info",
+                extra={k: v for k, v in row.items() if v},
+            ))
+
+        log.info(f"Parsed {len(entries)} entries from CSV: {path.name}")
+        return entries
+
+
+def _find_column(headers: dict[str, str], candidates: set[str]) -> str | None:
+    """Find the first matching column name from a set of candidates."""
+    for candidate in candidates:
+        if candidate in headers:
+            return headers[candidate]
+    return None
+
+
+def _normalize_severity(raw: str) -> str:
+    """Normalize severity string to standard levels."""
+    lower = raw.lower().strip()
+    if lower in ("critical", "crit", "fatal", "emergency"):
+        return "critical"
+    if lower in ("error", "err", "high"):
+        return "error"
+    if lower in ("warning", "warn", "medium"):
+        return "warning"
+    if lower in ("info", "information", "notice", "low"):
+        return "info"
+    if lower in ("debug", "trace", "verbose"):
+        return "debug"
+    return "info"
+
+
+def _classify_siprotec_event(description: str, event_id: str) -> str:
+    """Classify a SIPROTEC event into an ECS category."""
+    lower = (description + " " + event_id).lower()
+    if any(kw in lower for kw in ("fault", "trip", "protection", "overcurrent")):
+        return "process"
+    if any(kw in lower for kw in ("config", "download", "upload", "setting")):
+        return "configuration"
+    if any(kw in lower for kw in ("login", "logout", "auth", "password", "user")):
+        return "authentication"
+    if any(kw in lower for kw in ("comm", "network", "ethernet", "port")):
+        return "network"
+    return "process"

--- a/peat/forensic/pcap.py
+++ b/peat/forensic/pcap.py
@@ -1,0 +1,604 @@
+"""
+Network packet capture analysis pipeline for ICS/SCADA protocols.
+
+Implements a tiered PCAP processing pipeline:
+  Stage 1 (Triage): dpkt for high-speed flow extraction and port identification
+  Stage 2 (Deep dissection): scapy for ICS protocol parsing on identified flows
+
+Supports: Modbus TCP, DNP3, EtherNet/IP (CIP), S7comm, BACnet, and
+generic TCP/UDP flow analysis.
+
+@decision: Uses dpkt for Stage 1 triage (250K+ pkts/sec) and scapy for
+Stage 2 deep dissection. dpkt is ~50x faster than scapy for bulk packet
+iteration but lacks ICS protocol awareness. scapy has contrib modules for
+Modbus and EtherNet/IP but is too slow for full-capture processing. The
+tiered approach gives us speed for triage and depth for ICS analysis.
+pyshark (TShark wrapper) was considered for S7comm/BACnet/GOOSE but adds
+a heavy external dependency; we use port-based identification instead and
+defer deep dissection of those protocols to optional Zeek integration.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from peat import config, log
+
+
+# Well-known ICS protocol ports
+ICS_PORTS: dict[int, str] = {
+    102: "s7comm",
+    502: "modbus_tcp",
+    2222: "enip_io",
+    4840: "opcua",
+    4843: "opcua_tls",
+    18245: "ge_srtp",
+    20000: "dnp3",
+    44818: "enip",
+    47808: "bacnet",
+}
+
+# Additional ports for passive fingerprinting
+SCADA_PORTS: dict[int, str] = {
+    23: "telnet",
+    80: "http",
+    102: "s7comm",
+    443: "https",
+    502: "modbus_tcp",
+    2222: "enip_io",
+    2404: "iec104",
+    4840: "opcua",
+    20000: "dnp3",
+    44818: "enip",
+    47808: "bacnet",
+}
+
+
+@dataclass
+class NetworkFlow:
+    """A summarized network flow between two endpoints."""
+
+    src_ip: str
+    dst_ip: str
+    src_port: int
+    dst_port: int
+    protocol: str  # tcp, udp
+    ics_protocol: str = ""  # Detected ICS protocol
+    packet_count: int = 0
+    byte_count: int = 0
+    first_seen: datetime | None = None
+    last_seen: datetime | None = None
+
+
+@dataclass
+class ICSEvent:
+    """An ICS protocol event extracted from packet data."""
+
+    timestamp: datetime | None = None
+    src_ip: str = ""
+    dst_ip: str = ""
+    src_port: int = 0
+    dst_port: int = 0
+    ics_protocol: str = ""
+    function_code: int = 0
+    function_name: str = ""
+    unit_id: int = 0
+    description: str = ""
+    is_request: bool = True
+    raw_payload: bytes = b""
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "ics_event": {
+                "protocol": self.ics_protocol,
+                "function_code": self.function_code,
+                "function_name": self.function_name,
+                "description": self.description,
+                "is_request": self.is_request,
+                "unit_id": self.unit_id,
+            },
+            "source": {"ip": self.src_ip, "port": self.src_port},
+            "destination": {"ip": self.dst_ip, "port": self.dst_port},
+        }
+        if self.timestamp:
+            result["@timestamp"] = self.timestamp.isoformat()
+        if self.extra:
+            result["extra"] = self.extra
+        return result
+
+
+@dataclass
+class AssetRecord:
+    """A device discovered via passive traffic analysis."""
+
+    ip: str
+    mac: str = ""
+    hostname: str = ""
+    protocols: set[str] = field(default_factory=set)
+    ports: set[int] = field(default_factory=set)
+    roles: set[str] = field(default_factory=set)  # e.g. "master", "slave", "hmi"
+    first_seen: datetime | None = None
+    last_seen: datetime | None = None
+    packet_count: int = 0
+
+
+@dataclass
+class PcapAnalysisResult:
+    """Results from analyzing a PCAP file."""
+
+    pcap_path: str
+    total_packets: int = 0
+    total_bytes: int = 0
+    duration_seconds: float = 0.0
+    flows: list[NetworkFlow] = field(default_factory=list)
+    ics_events: list[ICSEvent] = field(default_factory=list)
+    assets: list[AssetRecord] = field(default_factory=list)
+    protocol_summary: dict[str, int] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pcap_analysis": {
+                "pcap_path": self.pcap_path,
+                "total_packets": self.total_packets,
+                "total_bytes": self.total_bytes,
+                "duration_seconds": round(self.duration_seconds, 3),
+                "ics_flows": len([f for f in self.flows if f.ics_protocol]),
+                "total_flows": len(self.flows),
+                "ics_events": len(self.ics_events),
+                "assets_discovered": len(self.assets),
+                "protocol_summary": self.protocol_summary,
+                "errors": self.errors,
+            }
+        }
+
+
+def analyze_pcap(
+    pcap_path: Path,
+    output_dir: Path | None = None,
+    deep_dissect: bool = True,
+) -> PcapAnalysisResult:
+    """
+    Analyze a PCAP/PCAPNG file for ICS/SCADA traffic.
+
+    Stage 1: Fast triage with dpkt — extract flows, identify ICS ports.
+    Stage 2: Deep dissection with scapy — parse ICS protocol payloads.
+
+    Args:
+        pcap_path: Path to PCAP or PCAPNG file.
+        output_dir: Directory to write results.
+        deep_dissect: Enable Stage 2 scapy-based ICS protocol parsing.
+
+    Returns:
+        PcapAnalysisResult with flows, events, and asset inventory.
+    """
+    result = PcapAnalysisResult(pcap_path=str(pcap_path))
+
+    if output_dir is None and config.RUN_DIR:
+        output_dir = config.RUN_DIR / "forensic_pcap"
+    if output_dir:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Stage 1: Fast triage with dpkt
+    log.info(f"Stage 1: Triaging PCAP with dpkt: {pcap_path.name}")
+    flows, ics_packets = _stage1_triage(pcap_path, result)
+
+    log.info(
+        f"Triage complete: {result.total_packets:,} packets, "
+        f"{len(flows):,} flows, {len(ics_packets):,} ICS packets identified"
+    )
+
+    # Stage 2: Deep ICS protocol dissection
+    if deep_dissect and ics_packets:
+        log.info(f"Stage 2: Deep dissecting {len(ics_packets):,} ICS packets with scapy")
+        _stage2_dissect(ics_packets, result)
+        log.info(f"Dissection complete: {len(result.ics_events):,} ICS events extracted")
+
+    # Build asset inventory from flows
+    _build_asset_inventory(flows, result)
+    log.info(f"Asset inventory: {len(result.assets)} devices discovered passively")
+
+    # Write results
+    if output_dir:
+        _write_results(result, output_dir)
+
+    return result
+
+
+def _stage1_triage(
+    pcap_path: Path,
+    result: PcapAnalysisResult,
+) -> tuple[dict[str, NetworkFlow], list[tuple[float, bytes, str, str, int, int]]]:
+    """
+    Stage 1: Fast packet triage using dpkt.
+
+    Returns:
+        Tuple of (flows_dict, ics_packets_list).
+        ics_packets_list contains (timestamp, payload, src_ip, dst_ip, src_port, dst_port).
+    """
+    import dpkt
+
+    flows: dict[str, NetworkFlow] = {}
+    ics_packets: list[tuple[float, bytes, str, str, int, int]] = []
+
+    try:
+        with open(pcap_path, "rb") as f:
+            try:
+                reader = dpkt.pcap.Reader(f)
+            except ValueError:
+                f.seek(0)
+                reader = dpkt.pcapng.Reader(f)
+
+            first_ts = None
+            last_ts = None
+
+            for ts, buf in reader:
+                result.total_packets += 1
+                result.total_bytes += len(buf)
+
+                if first_ts is None:
+                    first_ts = ts
+                last_ts = ts
+
+                # Parse Ethernet frame
+                try:
+                    eth = dpkt.ethernet.Ethernet(buf)
+                except (dpkt.NeedData, dpkt.UnpackError):
+                    continue
+
+                if not isinstance(eth.data, dpkt.ip.IP):
+                    continue
+
+                ip = eth.data
+                src_ip = _inet_ntoa(ip.src)
+                dst_ip = _inet_ntoa(ip.dst)
+
+                if isinstance(ip.data, dpkt.tcp.TCP):
+                    transport = ip.data
+                    proto = "tcp"
+                elif isinstance(ip.data, dpkt.udp.UDP):
+                    transport = ip.data
+                    proto = "udp"
+                else:
+                    continue
+
+                src_port = transport.sport
+                dst_port = transport.dport
+
+                # Build flow key (bidirectional)
+                flow_key = _flow_key(src_ip, dst_ip, src_port, dst_port, proto)
+                pkt_time = datetime.fromtimestamp(ts, tz=timezone.utc)
+
+                if flow_key not in flows:
+                    ics_proto = _identify_ics_protocol(src_port, dst_port)
+                    flows[flow_key] = NetworkFlow(
+                        src_ip=src_ip,
+                        dst_ip=dst_ip,
+                        src_port=src_port,
+                        dst_port=dst_port,
+                        protocol=proto,
+                        ics_protocol=ics_proto,
+                        first_seen=pkt_time,
+                    )
+                    if ics_proto:
+                        result.protocol_summary[ics_proto] = (
+                            result.protocol_summary.get(ics_proto, 0) + 1
+                        )
+
+                flow = flows[flow_key]
+                flow.packet_count += 1
+                flow.byte_count += len(buf)
+                flow.last_seen = pkt_time
+
+                # Collect ICS packets for Stage 2
+                payload = bytes(transport.data)
+                if payload and flow.ics_protocol:
+                    ics_packets.append((ts, payload, src_ip, dst_ip, src_port, dst_port))
+
+            if first_ts and last_ts:
+                result.duration_seconds = last_ts - first_ts
+
+    except Exception as e:
+        error_msg = f"dpkt triage failed: {e}"
+        log.error(error_msg)
+        result.errors.append(error_msg)
+
+    result.flows = list(flows.values())
+    return flows, ics_packets
+
+
+def _stage2_dissect(
+    ics_packets: list[tuple[float, bytes, str, str, int, int]],
+    result: PcapAnalysisResult,
+) -> None:
+    """
+    Stage 2: Deep ICS protocol dissection using scapy and manual parsing.
+
+    Parses Modbus TCP, DNP3, and EtherNet/IP payloads from collected packets.
+    """
+    for ts, payload, src_ip, dst_ip, src_port, dst_port in ics_packets:
+        timestamp = datetime.fromtimestamp(ts, tz=timezone.utc)
+        ics_proto = _identify_ics_protocol(src_port, dst_port)
+
+        events: list[ICSEvent] = []
+        if ics_proto == "modbus_tcp":
+            events = _dissect_modbus(payload, timestamp, src_ip, dst_ip, src_port, dst_port)
+        elif ics_proto == "dnp3":
+            events = _dissect_dnp3(payload, timestamp, src_ip, dst_ip, src_port, dst_port)
+        elif ics_proto in ("enip", "enip_io"):
+            events = _dissect_enip(payload, timestamp, src_ip, dst_ip, src_port, dst_port)
+        elif ics_proto:
+            # Port-identified but no deep parser — record as generic ICS event
+            events = [ICSEvent(
+                timestamp=timestamp,
+                src_ip=src_ip, dst_ip=dst_ip,
+                src_port=src_port, dst_port=dst_port,
+                ics_protocol=ics_proto,
+                description=f"{ics_proto} traffic ({len(payload)} bytes)",
+            )]
+
+        result.ics_events.extend(events)
+
+
+# -- Protocol dissectors --
+
+_MODBUS_FUNCTIONS: dict[int, str] = {
+    1: "Read Coils",
+    2: "Read Discrete Inputs",
+    3: "Read Holding Registers",
+    4: "Read Input Registers",
+    5: "Write Single Coil",
+    6: "Write Single Register",
+    15: "Write Multiple Coils",
+    16: "Write Multiple Registers",
+    22: "Mask Write Register",
+    23: "Read/Write Multiple Registers",
+    43: "Read Device Identification",
+}
+
+
+def _dissect_modbus(
+    payload: bytes, timestamp: datetime,
+    src_ip: str, dst_ip: str, src_port: int, dst_port: int,
+) -> list[ICSEvent]:
+    """Parse Modbus TCP/IP payload (MBAP header + PDU)."""
+    if len(payload) < 8:  # MBAP header is 7 bytes + at least 1 byte PDU
+        return []
+
+    # MBAP Header: transaction_id(2) + protocol_id(2) + length(2) + unit_id(1)
+    try:
+        transaction_id, protocol_id, length, unit_id = struct.unpack(">HHHB", payload[:7])
+    except struct.error:
+        return []
+
+    if protocol_id != 0:  # Modbus protocol ID is always 0
+        return []
+
+    function_code = payload[7] if len(payload) > 7 else 0
+    is_exception = function_code >= 0x80
+    actual_fc = function_code - 0x80 if is_exception else function_code
+    fc_name = _MODBUS_FUNCTIONS.get(actual_fc, f"FC {actual_fc}")
+    is_request = dst_port == 502
+
+    desc = f"{'Exception: ' if is_exception else ''}{fc_name}"
+    if is_exception and len(payload) > 8:
+        desc += f" (exception code: {payload[8]})"
+
+    extra: dict[str, Any] = {"transaction_id": transaction_id}
+
+    # Extract register addresses for read/write functions
+    if not is_exception and len(payload) >= 12 and actual_fc in (1, 2, 3, 4, 5, 6, 15, 16):
+        start_addr = struct.unpack(">H", payload[8:10])[0]
+        quantity = struct.unpack(">H", payload[10:12])[0]
+        extra["start_address"] = start_addr
+        extra["quantity"] = quantity
+        desc += f" addr={start_addr} qty={quantity}"
+
+    return [ICSEvent(
+        timestamp=timestamp,
+        src_ip=src_ip, dst_ip=dst_ip,
+        src_port=src_port, dst_port=dst_port,
+        ics_protocol="modbus_tcp",
+        function_code=actual_fc,
+        function_name=fc_name,
+        unit_id=unit_id,
+        description=desc,
+        is_request=is_request,
+        extra=extra,
+    )]
+
+
+_DNP3_FUNCTIONS: dict[int, str] = {
+    0x00: "Confirm",
+    0x01: "Read",
+    0x02: "Write",
+    0x03: "Select",
+    0x04: "Operate",
+    0x05: "Direct Operate",
+    0x06: "Direct Operate No Ack",
+    0x81: "Response",
+    0x82: "Unsolicited Response",
+}
+
+
+def _dissect_dnp3(
+    payload: bytes, timestamp: datetime,
+    src_ip: str, dst_ip: str, src_port: int, dst_port: int,
+) -> list[ICSEvent]:
+    """Parse DNP3 over TCP payload (start bytes + header)."""
+    if len(payload) < 10:
+        return []
+
+    # DNP3 start bytes: 0x0564
+    if payload[0:2] != b"\x05\x64":
+        return []
+
+    length = payload[2]
+    control = payload[3]
+    dst_addr = struct.unpack("<H", payload[4:6])[0]
+    src_addr = struct.unpack("<H", payload[6:8])[0]
+
+    # Data link header is 10 bytes: start(2) + len(1) + ctrl(1) + dst(2) + src(2) + crc(2)
+    # Transport header at [10], app control at [11], function code at [12]
+    if len(payload) < 13:
+        return []
+
+    # Transport header is 1 byte, then application control + function code
+    function_code = payload[12]
+    fc_name = _DNP3_FUNCTIONS.get(function_code, f"FC 0x{function_code:02x}")
+    is_request = function_code < 0x80
+
+    return [ICSEvent(
+        timestamp=timestamp,
+        src_ip=src_ip, dst_ip=dst_ip,
+        src_port=src_port, dst_port=dst_port,
+        ics_protocol="dnp3",
+        function_code=function_code,
+        function_name=fc_name,
+        unit_id=dst_addr,
+        description=f"{fc_name} (src_addr={src_addr}, dst_addr={dst_addr})",
+        is_request=is_request,
+        extra={"src_address": src_addr, "dst_address": dst_addr, "dnp3_length": length},
+    )]
+
+
+def _dissect_enip(
+    payload: bytes, timestamp: datetime,
+    src_ip: str, dst_ip: str, src_port: int, dst_port: int,
+) -> list[ICSEvent]:
+    """Parse EtherNet/IP encapsulation header."""
+    if len(payload) < 24:  # ENIP header is 24 bytes
+        return []
+
+    _ENIP_COMMANDS: dict[int, str] = {
+        0x0001: "ListTargets",
+        0x0004: "ListServices",
+        0x0063: "ListIdentity",
+        0x0064: "ListInterfaces",
+        0x0065: "RegisterSession",
+        0x0066: "UnregisterSession",
+        0x006F: "SendRRData",
+        0x0070: "SendUnitData",
+    }
+
+    try:
+        command = struct.unpack("<H", payload[0:2])[0]
+        length = struct.unpack("<H", payload[2:4])[0]
+        session_handle = struct.unpack("<I", payload[4:8])[0]
+    except struct.error:
+        return []
+
+    cmd_name = _ENIP_COMMANDS.get(command, f"Cmd 0x{command:04x}")
+
+    return [ICSEvent(
+        timestamp=timestamp,
+        src_ip=src_ip, dst_ip=dst_ip,
+        src_port=src_port, dst_port=dst_port,
+        ics_protocol="enip",
+        function_code=command,
+        function_name=cmd_name,
+        description=f"{cmd_name} (session=0x{session_handle:08x}, len={length})",
+        is_request=dst_port == 44818,
+        extra={"session_handle": session_handle, "enip_length": length},
+    )]
+
+
+# -- Utility functions --
+
+def _inet_ntoa(packed: bytes) -> str:
+    """Convert packed 4-byte IP to dotted notation."""
+    return ".".join(str(b) for b in packed[:4])
+
+
+def _flow_key(src_ip: str, dst_ip: str, src_port: int, dst_port: int, proto: str) -> str:
+    """Create a bidirectional flow key."""
+    a = (src_ip, src_port)
+    b = (dst_ip, dst_port)
+    if a > b:
+        a, b = b, a
+    return f"{proto}:{a[0]}:{a[1]}-{b[0]}:{b[1]}"
+
+
+def _identify_ics_protocol(src_port: int, dst_port: int) -> str:
+    """Identify ICS protocol by port number."""
+    if dst_port in ICS_PORTS:
+        return ICS_PORTS[dst_port]
+    if src_port in ICS_PORTS:
+        return ICS_PORTS[src_port]
+    return ""
+
+
+def _build_asset_inventory(
+    flows: dict[str, NetworkFlow],
+    result: PcapAnalysisResult,
+) -> None:
+    """Build a passive asset inventory from observed network flows."""
+    assets: dict[str, AssetRecord] = {}
+
+    for flow in flows.values():
+        for ip, port, role in [
+            (flow.src_ip, flow.src_port, "client"),
+            (flow.dst_ip, flow.dst_port, "server"),
+        ]:
+            if ip not in assets:
+                assets[ip] = AssetRecord(ip=ip, first_seen=flow.first_seen)
+
+            asset = assets[ip]
+            asset.ports.add(port)
+            asset.packet_count += flow.packet_count
+            if flow.ics_protocol:
+                asset.protocols.add(flow.ics_protocol)
+                asset.roles.add(role)
+            if flow.last_seen and (not asset.last_seen or flow.last_seen > asset.last_seen):
+                asset.last_seen = flow.last_seen
+
+    result.assets = list(assets.values())
+
+
+def _write_results(result: PcapAnalysisResult, output_dir: Path) -> None:
+    """Write PCAP analysis results to files."""
+    # Summary
+    summary_path = output_dir / "pcap-analysis-summary.json"
+    try:
+        summary_path.write_text(json.dumps(result.to_dict(), indent=4))
+    except OSError as e:
+        log.warning(f"Failed to write summary: {e}")
+
+    # ICS events as NDJSON
+    if result.ics_events:
+        events_path = output_dir / "ics-events.ndjson"
+        try:
+            with open(events_path, "w") as f:
+                for event in result.ics_events:
+                    f.write(json.dumps(event.to_dict(), default=str) + "\n")
+            log.debug(f"ICS events: {events_path} ({len(result.ics_events)} events)")
+        except OSError as e:
+            log.warning(f"Failed to write events: {e}")
+
+    # Asset inventory
+    if result.assets:
+        assets_path = output_dir / "asset-inventory.json"
+        try:
+            inventory = [
+                {
+                    "ip": a.ip,
+                    "protocols": sorted(a.protocols),
+                    "ports": sorted(a.ports),
+                    "roles": sorted(a.roles),
+                    "packet_count": a.packet_count,
+                    "first_seen": a.first_seen.isoformat() if a.first_seen else None,
+                    "last_seen": a.last_seen.isoformat() if a.last_seen else None,
+                }
+                for a in result.assets
+            ]
+            assets_path.write_text(json.dumps(inventory, indent=4))
+            log.debug(f"Asset inventory: {assets_path} ({len(inventory)} devices)")
+        except OSError as e:
+            log.warning(f"Failed to write inventory: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,16 @@ dependencies = [
     # Required for: Fortigate
     "scp>=0.15.0",
     "textual>=6.1.0",
+
+    # Forensic disk image analysis framework (Fox-IT/NCC Group)
+    # Provides unified abstraction over E01, VMDK, VHD, QCoW containers
+    # and NTFS, ExtFS, FAT, QNX, SquashFS, JFFS2 filesystems.
+    # Required for: peat forensic (disk image analysis)
+    "dissect>=3.0",
+
+    # High-speed PCAP parsing for network forensics
+    # Required for: peat forensic (PCAP analysis triage stage)
+    "dpkt>=1.9",
 ]
 
 [project.scripts]

--- a/tests/forensic/__init__.py
+++ b/tests/forensic/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the PEAT forensic module."""

--- a/tests/forensic/test_firmware.py
+++ b/tests/forensic/test_firmware.py
@@ -1,0 +1,158 @@
+"""
+Tests for firmware binary analysis and extraction.
+
+@decision: Tests create synthetic firmware blobs with known signatures
+rather than using real device firmware. This avoids licensing issues
+with vendor firmware and keeps the test suite fast and self-contained.
+"""
+
+import struct
+import zlib
+from pathlib import Path
+
+import pytest
+
+from peat.forensic.firmware import (
+    SIGNATURES,
+    FirmwareAnalysisResult,
+    FirmwareRegion,
+    analyze_firmware,
+)
+
+
+class TestSignatureDetection:
+    """Tests for magic byte detection in firmware binaries."""
+
+    def test_detect_vxworks_estfbinr(self, tmp_path: Path) -> None:
+        """Detect VxWorks ESTFBINR signature."""
+        payload = zlib.compress(b"VxWorks configuration data here")
+        data = b"ESTFBINR" + payload
+        fw = tmp_path / "firmware.bin"
+        fw.write_bytes(data)
+
+        result = analyze_firmware(fw, output_dir=tmp_path / "out")
+
+        assert len(result.regions) >= 1
+        vxworks_regions = [r for r in result.regions if r.signature_type == "vxworks_estfbinr"]
+        assert len(vxworks_regions) == 1
+        assert vxworks_regions[0].offset == 0
+
+    def test_detect_elf(self, tmp_path: Path) -> None:
+        """Detect ELF binary signature."""
+        # Minimal 32-bit ELF header
+        elf_header = b"\x7fELF"
+        elf_header += b"\x01"  # 32-bit
+        elf_header += b"\x01"  # little-endian
+        elf_header += b"\x01"  # ELF version
+        elf_header += b"\x00" * 9  # padding
+        elf_header += b"\x02\x00"  # ET_EXEC
+        elf_header += b"\x00" * 14  # rest of header
+        elf_header += struct.pack("<I", 52)  # e_shoff
+        elf_header += b"\x00" * 8  # flags, ehsize, phentsize
+        elf_header += b"\x00\x00"  # phnum
+        elf_header += struct.pack("<H", 40)  # e_shentsize
+        elf_header += struct.pack("<H", 1)  # e_shnum
+        elf_header += b"\x00" * (92 - len(elf_header))  # pad to expected size
+
+        fw = tmp_path / "firmware.elf"
+        fw.write_bytes(elf_header)
+
+        result = analyze_firmware(fw, output_dir=tmp_path / "out")
+
+        elf_regions = [r for r in result.regions if r.signature_type == "elf"]
+        assert len(elf_regions) == 1
+        assert "ELF" in elf_regions[0].description
+
+    def test_detect_squashfs(self, tmp_path: Path) -> None:
+        """Detect SquashFS signature."""
+        # hsqs magic followed by dummy data
+        data = b"\x00" * 100 + b"hsqs" + b"\x00" * 100
+        fw = tmp_path / "firmware.bin"
+        fw.write_bytes(data)
+
+        result = analyze_firmware(fw, output_dir=tmp_path / "out")
+
+        squash_regions = [r for r in result.regions if r.signature_type == "squashfs_le"]
+        assert len(squash_regions) == 1
+        assert squash_regions[0].offset == 100
+
+    def test_detect_multiple_signatures(self, tmp_path: Path) -> None:
+        """Detect multiple signatures in a single binary."""
+        data = b"\x7fELF" + b"\x01\x01\x01" + b"\x00" * 93  # ELF
+        data += b"ESTFBINR" + zlib.compress(b"payload")  # VxWorks
+        fw = tmp_path / "combo.bin"
+        fw.write_bytes(data)
+
+        result = analyze_firmware(fw, output_dir=tmp_path / "out")
+
+        types = {r.signature_type for r in result.regions}
+        assert "elf" in types
+        assert "vxworks_estfbinr" in types
+
+    def test_no_signatures_found(self, tmp_path: Path) -> None:
+        """Binary with no known signatures."""
+        fw = tmp_path / "random.bin"
+        fw.write_bytes(b"\xde\xad\xbe\xef" * 100)
+
+        result = analyze_firmware(fw, output_dir=tmp_path / "out")
+
+        assert len(result.regions) == 0
+
+
+class TestVxWorksExtraction:
+    """Tests for VxWorks ESTFBINR extraction."""
+
+    def test_extract_zlib_payload(self, tmp_path: Path) -> None:
+        """Extract and decompress zlib payload from ESTFBINR container."""
+        original = b"This is VxWorks configuration data for a PLC"
+        compressed = zlib.compress(original)
+        fw = tmp_path / "vxworks.bin"
+        fw.write_bytes(b"ESTFBINR" + compressed)
+
+        out_dir = tmp_path / "extracted"
+        result = analyze_firmware(fw, output_dir=out_dir)
+
+        assert len(result.extracted_files) >= 1
+        # Read back the extracted file
+        extracted_path = Path(result.extracted_files[0])
+        assert extracted_path.exists()
+        assert extracted_path.read_bytes() == original
+
+    def test_extract_raw_payload(self, tmp_path: Path) -> None:
+        """Extract raw (non-compressed) ESTFBINR payload."""
+        raw_payload = b"\x00\x01\x02\x03" * 100  # Not valid zlib
+        fw = tmp_path / "vxworks_raw.bin"
+        fw.write_bytes(b"ESTFBINR" + raw_payload)
+
+        out_dir = tmp_path / "extracted"
+        result = analyze_firmware(fw, output_dir=out_dir)
+
+        vxworks_regions = [r for r in result.regions if r.signature_type == "vxworks_estfbinr"]
+        assert len(vxworks_regions) == 1
+        assert len(result.extracted_files) >= 1
+
+
+class TestAnalysisResult:
+    """Tests for result serialization."""
+
+    def test_result_to_dict(self, tmp_path: Path) -> None:
+        fw = tmp_path / "test.bin"
+        fw.write_bytes(b"ESTFBINR" + zlib.compress(b"data"))
+
+        result = analyze_firmware(fw, output_dir=tmp_path / "out")
+        d = result.to_dict()
+
+        assert "firmware_analysis" in d
+        fa = d["firmware_analysis"]
+        assert fa["file_size"] > 0
+        assert fa["regions_found"] >= 1
+        assert isinstance(fa["regions"], list)
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        fw = tmp_path / "empty.bin"
+        fw.write_bytes(b"")
+
+        result = analyze_firmware(fw, output_dir=tmp_path / "out")
+
+        assert result.file_size == 0
+        assert len(result.regions) == 0

--- a/tests/forensic/test_image.py
+++ b/tests/forensic/test_image.py
@@ -1,0 +1,165 @@
+"""
+Tests for forensic disk image analysis.
+
+@decision: Tests focus on the pattern matching and artifact collection logic
+rather than actual disk image parsing, since creating valid E01/VMDK images
+in tests would require large fixtures. The dissect framework's own tests
+validate container/filesystem parsing. We test the PEAT-specific logic:
+ICS pattern collection, file matching, result serialization, and the
+extraction workflow. The fs parameter in _check_and_extract is unused
+when extract_artifacts=False, so we pass None instead of mocking.
+"""
+
+import pytest
+
+from peat.forensic.image import (
+    ExtractedArtifact,
+    ImageAnalysisResult,
+    _check_and_extract,
+    _get_ics_file_patterns,
+    _EXTRA_ICS_PATTERNS,
+    _EXCLUDED_DIRS,
+)
+
+
+class TestICSFilePatterns:
+    """Tests for ICS artifact pattern collection."""
+
+    def test_extra_patterns_exist(self) -> None:
+        """Built-in ICS patterns should be populated."""
+        assert "ics_project" in _EXTRA_ICS_PATTERNS
+        assert "ics_firmware" in _EXTRA_ICS_PATTERNS
+        assert "ics_log" in _EXTRA_ICS_PATTERNS
+        assert "ics_config" in _EXTRA_ICS_PATTERNS
+
+    def test_extra_patterns_contain_known_extensions(self) -> None:
+        """Known ICS file extensions should be in the patterns."""
+        all_patterns = []
+        for pats in _EXTRA_ICS_PATTERNS.values():
+            all_patterns.extend(pats)
+
+        assert "*.l5x" in all_patterns  # Rockwell
+        assert "*.apx" in all_patterns  # Schneider M340
+        assert "*.rdb" in all_patterns  # SEL
+        assert "*.wset" in all_patterns  # Woodward
+        assert "*.ser" in all_patterns  # SEL event logs
+        assert "*.cev" in all_patterns  # SEL event files
+
+    def test_get_ics_file_patterns_returns_dict(self) -> None:
+        """Module patterns function should return a dict."""
+        patterns = _get_ics_file_patterns()
+        assert isinstance(patterns, dict)
+
+    def test_excluded_dirs(self) -> None:
+        """Common non-ICS directories should be excluded."""
+        assert "windows" in _EXCLUDED_DIRS
+        assert "$recycle.bin" in _EXCLUDED_DIRS
+        assert "system volume information" in _EXCLUDED_DIRS
+
+
+class TestArtifactMatching:
+    """Tests for file pattern matching against ICS artifacts.
+
+    _check_and_extract only touches the fs object when extracting files
+    or getting file size. With extract_artifacts=False and output_dir=None,
+    fs is unused, so we pass None.
+    """
+
+    def test_match_l5x_file(self) -> None:
+        """L5X files should match Rockwell patterns."""
+        patterns = {"ics_project": ["*.l5x", "*.L5X"]}
+        result = ImageAnalysisResult(image_path="test.dd", image_type="dd")
+
+        _check_and_extract(None, "/projects/main.l5x", "main.l5x", result, patterns, None, False)
+
+        assert len(result.artifacts) == 1
+        assert result.artifacts[0].file_name == "main.l5x"
+        assert result.artifacts[0].matched_module == "ics_project"
+
+    def test_match_rdb_file(self) -> None:
+        """RDB files should match SEL patterns."""
+        patterns = {"ics_project": ["*.rdb", "*.RDB"]}
+        result = ImageAnalysisResult(image_path="test.dd", image_type="dd")
+
+        _check_and_extract(None, "/sel/relay.rdb", "relay.rdb", result, patterns, None, False)
+
+        assert len(result.artifacts) == 1
+        assert result.artifacts[0].matched_pattern == "*.rdb"
+
+    def test_match_case_insensitive(self) -> None:
+        """Pattern matching should be case-insensitive."""
+        patterns = {"ics_project": ["*.L5X"]}
+        result = ImageAnalysisResult(image_path="test.dd", image_type="dd")
+
+        _check_and_extract(None, "/proj/MAIN.l5x", "MAIN.l5x", result, patterns, None, False)
+
+        assert len(result.artifacts) == 1
+
+    def test_no_match(self) -> None:
+        """Non-ICS files should not match."""
+        patterns = {"ics_project": ["*.l5x"]}
+        result = ImageAnalysisResult(image_path="test.dd", image_type="dd")
+
+        _check_and_extract(None, "/docs/readme.pdf", "readme.pdf", result, patterns, None, False)
+
+        assert len(result.artifacts) == 0
+
+    def test_match_sel_set_pattern(self) -> None:
+        """SEL SET_*.TXT files should match."""
+        patterns = {"ics_log": ["SET_*.TXT", "set_*.txt"]}
+        result = ImageAnalysisResult(image_path="test.dd", image_type="dd")
+
+        _check_and_extract(None, "/sel/SET_1.TXT", "SET_1.TXT", result, patterns, None, False)
+
+        assert len(result.artifacts) == 1
+
+    def test_first_match_wins(self) -> None:
+        """Only the first matching pattern should be recorded per file."""
+        patterns = {
+            "source_a": ["*.bin"],
+            "source_b": ["*.bin"],
+        }
+        result = ImageAnalysisResult(image_path="test.dd", image_type="dd")
+
+        _check_and_extract(None, "/fw/plc.bin", "plc.bin", result, patterns, None, False)
+
+        assert len(result.artifacts) == 1  # Not 2
+
+
+class TestImageAnalysisResult:
+    """Tests for result serialization."""
+
+    def test_to_dict_structure(self) -> None:
+        result = ImageAnalysisResult(
+            image_path="/evidence/disk.e01",
+            image_type="e01",
+            partitions_found=2,
+            filesystem_type="NTFS",
+            total_files_scanned=1500,
+        )
+        result.artifacts.append(
+            ExtractedArtifact(
+                virtual_path="/projects/main.l5x",
+                file_name="main.l5x",
+                file_size=45000,
+                matched_module="ControlLogix",
+                matched_pattern="*.l5x",
+            )
+        )
+
+        d = result.to_dict()
+
+        assert "image_analysis" in d
+        ia = d["image_analysis"]
+        assert ia["partitions_found"] == 2
+        assert ia["filesystem_type"] == "NTFS"
+        assert ia["total_files_scanned"] == 1500
+        assert ia["artifacts_found"] == 1
+        assert ia["artifacts"][0]["file_name"] == "main.l5x"
+
+    def test_empty_result(self) -> None:
+        result = ImageAnalysisResult(image_path="test.dd", image_type="dd")
+        d = result.to_dict()
+
+        assert d["image_analysis"]["artifacts_found"] == 0
+        assert d["image_analysis"]["total_files_scanned"] == 0

--- a/tests/forensic/test_init.py
+++ b/tests/forensic/test_init.py
@@ -1,0 +1,104 @@
+"""
+Tests for forensic input type detection.
+
+@decision: Tests cover both extension-based and magic-byte-based detection paths.
+Magic byte tests use minimal synthetic headers rather than real forensic images
+to keep the test suite fast and avoid shipping large binary fixtures.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from peat.forensic import ForensicInputType, detect_input_type
+
+
+class TestDetectInputType:
+    """Tests for detect_input_type function."""
+
+    def test_disk_image_by_extension(self, tmp_path: Path) -> None:
+        for ext in [".e01", ".dd", ".raw", ".img", ".vmdk", ".vhd", ".vhdx", ".qcow2"]:
+            f = tmp_path / f"evidence{ext}"
+            f.write_bytes(b"\x00" * 32)
+            assert detect_input_type(f) == ForensicInputType.DISK_IMAGE
+
+    def test_pcap_by_extension(self, tmp_path: Path) -> None:
+        for ext in [".pcap", ".pcapng", ".cap"]:
+            f = tmp_path / f"capture{ext}"
+            f.write_bytes(b"\x00" * 32)
+            assert detect_input_type(f) == ForensicInputType.PCAP
+
+    def test_log_by_extension(self, tmp_path: Path) -> None:
+        for ext in [".log", ".csv", ".txt", ".xml", ".ser"]:
+            f = tmp_path / f"events{ext}"
+            f.write_bytes(b"\x00" * 32)
+            assert detect_input_type(f) == ForensicInputType.LOG_FILE
+
+    def test_firmware_by_extension(self, tmp_path: Path) -> None:
+        for ext in [".bin", ".fw", ".rom", ".spi", ".elf", ".hex"]:
+            f = tmp_path / f"firmware{ext}"
+            f.write_bytes(b"\x00" * 32)
+            assert detect_input_type(f) == ForensicInputType.FIRMWARE
+
+    def test_directory_detected(self, tmp_path: Path) -> None:
+        assert detect_input_type(tmp_path) == ForensicInputType.LOG_DIRECTORY
+
+    def test_pcap_magic_le(self, tmp_path: Path) -> None:
+        """PCAP little-endian magic: 0xd4c3b2a1."""
+        f = tmp_path / "unknown.dat"
+        f.write_bytes(b"\xd4\xc3\xb2\xa1" + b"\x00" * 28)
+        assert detect_input_type(f) == ForensicInputType.PCAP
+
+    def test_pcap_magic_be(self, tmp_path: Path) -> None:
+        """PCAP big-endian magic: 0xa1b2c3d4."""
+        f = tmp_path / "unknown.dat"
+        f.write_bytes(b"\xa1\xb2\xc3\xd4" + b"\x00" * 28)
+        assert detect_input_type(f) == ForensicInputType.PCAP
+
+    def test_pcapng_magic(self, tmp_path: Path) -> None:
+        """PCAPNG Section Header Block magic."""
+        f = tmp_path / "unknown.dat"
+        f.write_bytes(b"\x0a\x0d\x0d\x0a" + b"\x00" * 28)
+        assert detect_input_type(f) == ForensicInputType.PCAP
+
+    def test_e01_magic(self, tmp_path: Path) -> None:
+        """E01 (EnCase) magic bytes."""
+        f = tmp_path / "unknown.dat"
+        f.write_bytes(b"EVF\x09\x0d\x0a\xff\x00" + b"\x00" * 24)
+        assert detect_input_type(f) == ForensicInputType.DISK_IMAGE
+
+    def test_vxworks_estfbinr_magic(self, tmp_path: Path) -> None:
+        """VxWorks ESTFBINR signature."""
+        f = tmp_path / "unknown.dat"
+        f.write_bytes(b"ESTFBINR" + b"\x00" * 24)
+        assert detect_input_type(f) == ForensicInputType.FIRMWARE
+
+    def test_elf_magic(self, tmp_path: Path) -> None:
+        """ELF binary magic."""
+        f = tmp_path / "unknown.dat"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 28)
+        assert detect_input_type(f) == ForensicInputType.FIRMWARE
+
+    def test_vmdk_magic(self, tmp_path: Path) -> None:
+        """VMDK sparse header magic."""
+        f = tmp_path / "unknown.dat"
+        f.write_bytes(b"KDMV" + b"\x00" * 28)
+        assert detect_input_type(f) == ForensicInputType.DISK_IMAGE
+
+    def test_unknown_falls_through(self, tmp_path: Path) -> None:
+        """Unknown extension + unknown magic -> UNKNOWN."""
+        f = tmp_path / "mystery.xyz"
+        f.write_bytes(b"not a known format header!!")
+        assert detect_input_type(f) == ForensicInputType.UNKNOWN
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        """Empty file with unknown extension -> UNKNOWN."""
+        f = tmp_path / "empty.xyz"
+        f.write_bytes(b"")
+        assert detect_input_type(f) == ForensicInputType.UNKNOWN
+
+    def test_small_file(self, tmp_path: Path) -> None:
+        """File too small for magic detection -> UNKNOWN."""
+        f = tmp_path / "tiny.xyz"
+        f.write_bytes(b"\x00\x01")
+        assert detect_input_type(f) == ForensicInputType.UNKNOWN

--- a/tests/forensic/test_integrity.py
+++ b/tests/forensic/test_integrity.py
@@ -1,0 +1,155 @@
+"""
+Tests for forensic integrity module.
+
+@decision: Tests use hashlib directly to compute expected values rather than
+hardcoding hex strings. This keeps tests resilient to platform differences
+and clearly shows the relationship between input data and expected output.
+"""
+
+import hashlib
+import io
+from pathlib import Path
+
+import pytest
+
+from peat.forensic.integrity import (
+    ForensicMetadata,
+    compute_hash_from_stream,
+    compute_hashes,
+    generate_forensic_metadata,
+    verify_hash,
+)
+
+
+class TestComputeHashes:
+    """Tests for hash computation functions."""
+
+    def test_known_hash(self, tmp_path: Path) -> None:
+        """Verify SHA-256 and MD5 against known values."""
+        content = b"PEAT forensic test data"
+        f = tmp_path / "test.bin"
+        f.write_bytes(content)
+
+        sha256_hex, md5_hex = compute_hashes(f)
+
+        assert sha256_hex == hashlib.sha256(content).hexdigest()
+        assert md5_hex == hashlib.md5(content).hexdigest()  # noqa: S324
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        """Empty file should produce the well-known empty-input hashes."""
+        f = tmp_path / "empty.bin"
+        f.write_bytes(b"")
+
+        sha256_hex, md5_hex = compute_hashes(f)
+
+        assert sha256_hex == hashlib.sha256(b"").hexdigest()
+        assert md5_hex == hashlib.md5(b"").hexdigest()  # noqa: S324
+
+    def test_large_file_streams(self, tmp_path: Path) -> None:
+        """File larger than buffer size (64KB) should still hash correctly."""
+        content = b"A" * 200_000  # ~200 KB
+        f = tmp_path / "large.bin"
+        f.write_bytes(content)
+
+        sha256_hex, md5_hex = compute_hashes(f)
+
+        assert sha256_hex == hashlib.sha256(content).hexdigest()
+
+    def test_nonexistent_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(OSError):
+            compute_hashes(tmp_path / "no_such_file.bin")
+
+
+class TestComputeHashFromStream:
+    """Tests for stream-based hashing."""
+
+    def test_sha256_stream(self) -> None:
+        data = b"stream test data"
+        stream = io.BytesIO(data)
+        result = compute_hash_from_stream(stream, "sha256")
+        assert result == hashlib.sha256(data).hexdigest()
+
+    def test_md5_stream(self) -> None:
+        data = b"stream test data"
+        stream = io.BytesIO(data)
+        result = compute_hash_from_stream(stream, "md5")
+        assert result == hashlib.md5(data).hexdigest()  # noqa: S324
+
+
+class TestVerifyHash:
+    """Tests for hash verification."""
+
+    def test_matching_hash(self, tmp_path: Path) -> None:
+        content = b"verify me"
+        f = tmp_path / "test.bin"
+        f.write_bytes(content)
+        expected = hashlib.sha256(content).hexdigest()
+
+        assert verify_hash(f, expected) is True
+
+    def test_mismatched_hash(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.bin"
+        f.write_bytes(b"actual content")
+
+        assert verify_hash(f, "0" * 64) is False
+
+    def test_case_insensitive(self, tmp_path: Path) -> None:
+        content = b"case test"
+        f = tmp_path / "test.bin"
+        f.write_bytes(content)
+        expected = hashlib.sha256(content).hexdigest().upper()
+
+        assert verify_hash(f, expected) is True
+
+
+class TestGenerateForensicMetadata:
+    """Tests for full metadata generation."""
+
+    def test_metadata_fields(self, tmp_path: Path) -> None:
+        content = b"metadata test"
+        f = tmp_path / "evidence.e01"
+        f.write_bytes(content)
+
+        meta = generate_forensic_metadata(f, notes="Test case 001")
+
+        assert meta.file_name == "evidence.e01"
+        assert meta.file_size == len(content)
+        assert meta.sha256 == hashlib.sha256(content).hexdigest()
+        assert meta.md5 == hashlib.md5(content).hexdigest()  # noqa: S324
+        assert meta.notes == "Test case 001"
+        assert meta.ingest_time  # non-empty
+        assert meta.original_modified_time  # non-empty
+        assert "evidence.e01" in meta.file_path
+
+    def test_to_dict_structure(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.bin"
+        f.write_bytes(b"dict test")
+
+        meta = generate_forensic_metadata(f)
+        d = meta.to_dict()
+
+        assert "forensic_integrity" in d
+        fi = d["forensic_integrity"]
+        assert "hashes" in fi
+        assert "sha256" in fi["hashes"]
+        assert "md5" in fi["hashes"]
+        assert "ingest_time_utc" in fi
+        assert "file_size" in fi
+
+    def test_to_dict_without_notes(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.bin"
+        f.write_bytes(b"no notes")
+
+        meta = generate_forensic_metadata(f)
+        d = meta.to_dict()
+
+        assert "notes" not in d["forensic_integrity"]
+
+    def test_to_dict_with_notes(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.bin"
+        f.write_bytes(b"with notes")
+
+        meta = generate_forensic_metadata(f, notes="Case 42")
+        d = meta.to_dict()
+
+        assert d["forensic_integrity"]["notes"] == "Case 42"

--- a/tests/forensic/test_log_parsers.py
+++ b/tests/forensic/test_log_parsers.py
@@ -1,0 +1,298 @@
+"""
+Tests for ICS/SCADA log file parsers.
+
+@decision: Tests use inline fixture strings that represent realistic but
+synthetic ICS log data. This avoids shipping vendor-proprietary log files
+in the test suite while ensuring parsers handle real-world formatting
+patterns (variable whitespace, mixed case, optional fields).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from peat.forensic.logs.base import ParsedLogEntry, LogParser
+from peat.forensic.logs.sel_parser import SELLogParser
+from peat.forensic.logs.siprotec_parser import SiprotecLogParser, GenericCSVLogParser
+from peat.forensic.logs.schneider_parser import SchneiderCommsParser
+from peat.forensic.logs.ingest import ingest_logs, PARSERS
+
+
+# -- SEL SER log fixtures --
+
+SEL_SER_LOG = """\
+FID=SEL-751-R107-V0-Z003003-D20260101
+
+Date       Time           Event                   Loc
+03/15/2026 14:23:45.123   RELAY TRIP               001
+03/15/2026 14:23:45.456   67P1T                    001
+03/15/2026 14:24:00.000   ALARM CLR                001
+03/15/2026 14:30:12.789   PORT 1 COMM FAIL         001
+03/15/2026 15:00:00.000   SET S01 CHANGED           002
+"""
+
+# -- Siemens SIPROTEC CSV fixture --
+
+SIPROTEC_CSV = """\
+Timestamp,Event ID,Description,Severity,Source
+2026-03-15 14:23:45,1001,Config download started,Info,DIGSI 5
+2026-03-15 14:24:12,1002,Config download complete,Info,DIGSI 5
+2026-03-15 14:25:00,2001,Overcurrent trip Phase A,Critical,Protection
+2026-03-15 14:30:00,3001,User admin login,Info,Security
+"""
+
+# -- Schneider ClearSCADA comms log fixture --
+
+SCHNEIDER_COMMS_LOG = """\
+Channel: Modbus RTU Port 1
+2026-03-15 14:23:45.123 TX 01 03 00 00 00 0A C5 CD
+2026-03-15 14:23:45.456 RX ACCEPTED 01 03 14 00 64 00 65
+2026-03-15 14:23:46.100 TX 01 06 00 01 00 0A D9 CA
+2026-03-15 14:23:46.500 RX REJECTED 01 86 02
+2026-03-15 14:23:47.000 TX 01 03 00 10 00 01 85 CF
+2026-03-15 14:23:48.000 RX TIMEOUT
+"""
+
+# -- Generic CSV fixture --
+
+GENERIC_CSV = """\
+Timestamp,Tag,Value,Quality
+2026-03-15 14:00:00,TANK_LEVEL,85.2,Good
+2026-03-15 14:01:00,TANK_LEVEL,85.5,Good
+2026-03-15 14:02:00,PUMP_STATUS,1,Good
+"""
+
+
+class TestSELLogParser:
+    """Tests for SEL SER log parser."""
+
+    def test_detect_ser_log(self, tmp_path: Path) -> None:
+        f = tmp_path / "SER.TXT"
+        f.write_text(SEL_SER_LOG)
+        assert SELLogParser.detect(f) is True
+
+    def test_detect_non_ser(self, tmp_path: Path) -> None:
+        f = tmp_path / "random.txt"
+        f.write_text("This is just a regular text file with no SER data.")
+        assert SELLogParser.detect(f) is False
+
+    def test_parse_event_count(self, tmp_path: Path) -> None:
+        f = tmp_path / "SER.TXT"
+        f.write_text(SEL_SER_LOG)
+        entries = SELLogParser.parse(f)
+        assert len(entries) == 5
+
+    def test_parse_timestamps(self, tmp_path: Path) -> None:
+        f = tmp_path / "SER.TXT"
+        f.write_text(SEL_SER_LOG)
+        entries = SELLogParser.parse(f)
+        assert entries[0].timestamp is not None
+        assert entries[0].timestamp.month == 3
+        assert entries[0].timestamp.day == 15
+
+    def test_parse_trip_event(self, tmp_path: Path) -> None:
+        f = tmp_path / "SER.TXT"
+        f.write_text(SEL_SER_LOG)
+        entries = SELLogParser.parse(f)
+        trip = entries[0]
+        assert "RELAY TRIP" in trip.message
+        assert trip.severity == "critical"
+        assert trip.action == "relay_trip"
+
+    def test_parse_comm_fail(self, tmp_path: Path) -> None:
+        f = tmp_path / "SER.TXT"
+        f.write_text(SEL_SER_LOG)
+        entries = SELLogParser.parse(f)
+        comm = entries[3]
+        assert "COMM" in comm.message
+        assert comm.category == "network"
+
+    def test_parse_config_change(self, tmp_path: Path) -> None:
+        f = tmp_path / "SER.TXT"
+        f.write_text(SEL_SER_LOG)
+        entries = SELLogParser.parse(f)
+        cfg = entries[4]
+        assert "SET" in cfg.message
+        assert cfg.action == "config_change"
+        assert cfg.category == "configuration"
+
+    def test_device_id_extraction(self, tmp_path: Path) -> None:
+        f = tmp_path / "SER.TXT"
+        f.write_text(SEL_SER_LOG)
+        entries = SELLogParser.parse(f)
+        assert entries[0].device_id == "SEL-751-R107-V0-Z003003-D20260101"
+
+    def test_vendor_set(self, tmp_path: Path) -> None:
+        f = tmp_path / "SER.TXT"
+        f.write_text(SEL_SER_LOG)
+        entries = SELLogParser.parse(f)
+        for e in entries:
+            assert e.device_vendor == "SEL"
+
+
+class TestSiprotecLogParser:
+    """Tests for Siemens SIPROTEC CSV parser."""
+
+    def test_detect_siprotec(self, tmp_path: Path) -> None:
+        f = tmp_path / "siprotec_diag.csv"
+        f.write_text(SIPROTEC_CSV)
+        # Detection relies on "DIGSI" in content
+        assert SiprotecLogParser.detect(f) is True
+
+    def test_parse_event_count(self, tmp_path: Path) -> None:
+        f = tmp_path / "siprotec_diag.csv"
+        f.write_text(SIPROTEC_CSV)
+        entries = SiprotecLogParser.parse(f)
+        assert len(entries) == 4
+
+    def test_parse_critical_event(self, tmp_path: Path) -> None:
+        f = tmp_path / "siprotec_diag.csv"
+        f.write_text(SIPROTEC_CSV)
+        entries = SiprotecLogParser.parse(f)
+        trip = entries[2]
+        assert "Overcurrent" in trip.message
+        assert trip.severity == "critical"
+
+    def test_vendor_set(self, tmp_path: Path) -> None:
+        f = tmp_path / "siprotec_diag.csv"
+        f.write_text(SIPROTEC_CSV)
+        entries = SiprotecLogParser.parse(f)
+        for e in entries:
+            assert e.device_vendor == "Siemens"
+
+
+class TestSchneiderCommsParser:
+    """Tests for Schneider ClearSCADA comms log parser."""
+
+    def test_detect_comms_log(self, tmp_path: Path) -> None:
+        f = tmp_path / "comms.log"
+        f.write_text(SCHNEIDER_COMMS_LOG)
+        assert SchneiderCommsParser.detect(f) is True
+
+    def test_parse_event_count(self, tmp_path: Path) -> None:
+        f = tmp_path / "comms.log"
+        f.write_text(SCHNEIDER_COMMS_LOG)
+        entries = SchneiderCommsParser.parse(f)
+        assert len(entries) == 6
+
+    def test_parse_tx_rx_direction(self, tmp_path: Path) -> None:
+        f = tmp_path / "comms.log"
+        f.write_text(SCHNEIDER_COMMS_LOG)
+        entries = SchneiderCommsParser.parse(f)
+        assert entries[0].extra["direction"] == "TX"
+        assert entries[1].extra["direction"] == "RX"
+
+    def test_parse_rejected_status(self, tmp_path: Path) -> None:
+        f = tmp_path / "comms.log"
+        f.write_text(SCHNEIDER_COMMS_LOG)
+        entries = SchneiderCommsParser.parse(f)
+        rejected = entries[3]
+        assert rejected.outcome == "failure"
+        assert rejected.severity == "warning"
+        assert rejected.extra["status"] == "REJECTED"
+
+    def test_parse_timeout(self, tmp_path: Path) -> None:
+        f = tmp_path / "comms.log"
+        f.write_text(SCHNEIDER_COMMS_LOG)
+        entries = SchneiderCommsParser.parse(f)
+        timeout = entries[5]
+        assert timeout.outcome == "failure"
+
+    def test_channel_info_captured(self, tmp_path: Path) -> None:
+        f = tmp_path / "comms.log"
+        f.write_text(SCHNEIDER_COMMS_LOG)
+        entries = SchneiderCommsParser.parse(f)
+        assert entries[0].extra.get("channel") == "Channel: Modbus RTU Port 1"
+
+
+class TestGenericCSVParser:
+    """Tests for generic CSV fallback parser."""
+
+    def test_detect_generic_csv(self, tmp_path: Path) -> None:
+        f = tmp_path / "historian_export.csv"
+        f.write_text(GENERIC_CSV)
+        assert GenericCSVLogParser.detect(f) is True
+
+    def test_parse_entries(self, tmp_path: Path) -> None:
+        f = tmp_path / "historian_export.csv"
+        f.write_text(GENERIC_CSV)
+        entries = GenericCSVLogParser.parse(f)
+        assert len(entries) == 3
+
+    def test_timestamps_parsed(self, tmp_path: Path) -> None:
+        f = tmp_path / "historian_export.csv"
+        f.write_text(GENERIC_CSV)
+        entries = GenericCSVLogParser.parse(f)
+        assert entries[0].timestamp is not None
+
+
+class TestECSOutput:
+    """Tests for ECS-compliant output format."""
+
+    def test_to_ecs_dict_structure(self) -> None:
+        entry = ParsedLogEntry(
+            message="RELAY TRIP",
+            original="03/15/2026 14:23:45.123 RELAY TRIP 001",
+            source_type="sel_ser",
+            action="relay_trip",
+            category="process",
+            severity="critical",
+            device_vendor="SEL",
+            device_model="SEL-751",
+            device_id="RELAY_001",
+        )
+        d = entry.to_ecs_dict()
+
+        assert "event" in d
+        assert d["event"]["action"] == "relay_trip"
+        assert d["event"]["severity"] == "critical"
+        assert d["event"]["dataset"] == "sel_ser"
+        assert "hash" in d["event"]  # SHA-256 of original line
+
+    def test_to_ecs_dict_with_network(self) -> None:
+        entry = ParsedLogEntry(
+            source_ip="192.168.1.100",
+            destination_ip="192.168.1.1",
+            source_port=502,
+        )
+        d = entry.to_ecs_dict()
+
+        assert d["source"]["ip"] == "192.168.1.100"
+        assert d["source"]["port"] == 502
+        assert d["destination"]["ip"] == "192.168.1.1"
+
+
+class TestLogIngestion:
+    """Tests for the unified log ingestion framework."""
+
+    def test_ingest_single_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "SER.TXT"
+        f.write_text(SEL_SER_LOG)
+        entries = ingest_logs(f, output_dir=tmp_path / "out")
+        assert len(entries) == 5
+
+    def test_ingest_directory(self, tmp_path: Path) -> None:
+        (tmp_path / "SER.TXT").write_text(SEL_SER_LOG)
+        (tmp_path / "siprotec.csv").write_text(SIPROTEC_CSV)
+        entries = ingest_logs(tmp_path, output_dir=tmp_path / "out")
+        assert len(entries) == 9  # 5 SEL + 4 SIPROTEC
+
+    def test_output_files_written(self, tmp_path: Path) -> None:
+        f = tmp_path / "SER.TXT"
+        f.write_text(SEL_SER_LOG)
+        out = tmp_path / "out"
+        ingest_logs(f, output_dir=out)
+        assert (out / "log-ingestion-summary.json").exists()
+        assert (out / "parsed-log-entries.ndjson").exists()
+
+    def test_parsers_registered(self) -> None:
+        """All expected parsers should be in the registry."""
+        parser_names = {p.name for p in PARSERS}
+        assert "sel_ser" in parser_names
+        assert "siprotec_csv" in parser_names
+        assert "schneider_comms" in parser_names
+        assert "generic_csv" in parser_names
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        entries = ingest_logs(tmp_path, output_dir=tmp_path / "out")
+        assert len(entries) == 0

--- a/tests/forensic/test_pcap.py
+++ b/tests/forensic/test_pcap.py
@@ -1,0 +1,317 @@
+"""
+Tests for PCAP analysis pipeline.
+
+@decision: Tests create synthetic PCAP files using dpkt to write real
+Ethernet/IP/TCP frames with embedded ICS protocol payloads. This avoids
+shipping real network captures (which may contain sensitive data) while
+testing the full pipeline end-to-end: dpkt triage -> ICS identification
+-> protocol dissection -> asset inventory generation.
+"""
+
+import struct
+import time
+from pathlib import Path
+
+import dpkt
+import pytest
+
+from peat.forensic.pcap import (
+    ICSEvent,
+    NetworkFlow,
+    PcapAnalysisResult,
+    analyze_pcap,
+    _dissect_modbus,
+    _dissect_dnp3,
+    _dissect_enip,
+    _identify_ics_protocol,
+    _flow_key,
+    ICS_PORTS,
+)
+from datetime import datetime, timezone
+
+
+def _build_pcap(tmp_path: Path, packets: list[tuple[bytes, bytes, int, int, bytes]]) -> Path:
+    """
+    Build a PCAP file from a list of (src_ip, dst_ip, src_port, dst_port, payload) tuples.
+
+    IPs should be 4-byte packed format. Returns path to the PCAP file.
+    """
+    pcap_path = tmp_path / "test.pcap"
+    writer = dpkt.pcap.Writer(open(pcap_path, "wb"))
+
+    for i, (src_ip, dst_ip, src_port, dst_port, payload) in enumerate(packets):
+        tcp = dpkt.tcp.TCP(
+            sport=src_port, dport=dst_port,
+            seq=1000 + i, ack=0, off=5, flags=dpkt.tcp.TH_ACK,
+            data=payload,
+        )
+        ip = dpkt.ip.IP(
+            src=src_ip, dst=dst_ip,
+            p=dpkt.ip.IP_PROTO_TCP,
+            data=tcp, len=20 + len(tcp),
+        )
+        eth = dpkt.ethernet.Ethernet(
+            src=b"\x00\x11\x22\x33\x44\x55",
+            dst=b"\x66\x77\x88\x99\xaa\xbb",
+            type=dpkt.ethernet.ETH_TYPE_IP,
+            data=ip,
+        )
+        writer.writepkt(bytes(eth), ts=time.time() + i * 0.001)
+
+    writer.close()
+    return pcap_path
+
+
+def _ip(a: int, b: int, c: int, d: int) -> bytes:
+    return bytes([a, b, c, d])
+
+
+def _modbus_read_request(unit_id: int, fc: int, start_addr: int, quantity: int) -> bytes:
+    """Build a Modbus TCP read request payload (MBAP + PDU)."""
+    pdu = struct.pack(">BHH", fc, start_addr, quantity)
+    mbap = struct.pack(">HHHB", 1, 0, len(pdu) + 1, unit_id)
+    return mbap + pdu
+
+
+class TestICSProtocolIdentification:
+    """Tests for port-based ICS protocol identification."""
+
+    def test_modbus_port(self) -> None:
+        assert _identify_ics_protocol(12345, 502) == "modbus_tcp"
+        assert _identify_ics_protocol(502, 12345) == "modbus_tcp"
+
+    def test_enip_port(self) -> None:
+        assert _identify_ics_protocol(12345, 44818) == "enip"
+
+    def test_dnp3_port(self) -> None:
+        assert _identify_ics_protocol(12345, 20000) == "dnp3"
+
+    def test_s7comm_port(self) -> None:
+        assert _identify_ics_protocol(12345, 102) == "s7comm"
+
+    def test_bacnet_port(self) -> None:
+        assert _identify_ics_protocol(12345, 47808) == "bacnet"
+
+    def test_non_ics_port(self) -> None:
+        assert _identify_ics_protocol(12345, 8080) == ""
+
+    def test_known_ports_populated(self) -> None:
+        assert 502 in ICS_PORTS
+        assert 44818 in ICS_PORTS
+        assert 20000 in ICS_PORTS
+
+
+class TestModbusDissector:
+    """Tests for Modbus TCP protocol dissection."""
+
+    def test_read_holding_registers(self) -> None:
+        payload = _modbus_read_request(unit_id=1, fc=3, start_addr=100, quantity=10)
+        ts = datetime(2026, 3, 15, 14, 0, 0, tzinfo=timezone.utc)
+
+        events = _dissect_modbus(payload, ts, "192.168.1.100", "192.168.1.1", 5000, 502)
+
+        assert len(events) == 1
+        e = events[0]
+        assert e.function_code == 3
+        assert e.function_name == "Read Holding Registers"
+        assert e.unit_id == 1
+        assert e.is_request is True
+        assert e.extra["start_address"] == 100
+        assert e.extra["quantity"] == 10
+
+    def test_write_single_register(self) -> None:
+        payload = _modbus_read_request(unit_id=2, fc=6, start_addr=40, quantity=500)
+        ts = datetime(2026, 3, 15, 14, 0, 0, tzinfo=timezone.utc)
+
+        events = _dissect_modbus(payload, ts, "192.168.1.100", "192.168.1.1", 5000, 502)
+
+        assert len(events) == 1
+        assert events[0].function_name == "Write Single Register"
+
+    def test_exception_response(self) -> None:
+        # Modbus exception: FC 0x83 (Read Holding Registers exception) + exception code 2
+        pdu = struct.pack(">BB", 0x83, 0x02)
+        mbap = struct.pack(">HHHB", 1, 0, len(pdu) + 1, 1)
+        payload = mbap + pdu
+        ts = datetime(2026, 3, 15, 14, 0, 0, tzinfo=timezone.utc)
+
+        events = _dissect_modbus(payload, ts, "192.168.1.1", "192.168.1.100", 502, 5000)
+
+        assert len(events) == 1
+        assert "Exception" in events[0].description
+        assert events[0].is_request is False
+
+    def test_too_short_payload(self) -> None:
+        events = _dissect_modbus(
+            b"\x00\x01", datetime.now(timezone.utc),
+            "1.2.3.4", "5.6.7.8", 1000, 502,
+        )
+        assert len(events) == 0
+
+    def test_non_modbus_protocol_id(self) -> None:
+        # Protocol ID != 0 means not Modbus
+        payload = struct.pack(">HHHBB", 1, 99, 2, 1, 3)
+        events = _dissect_modbus(
+            payload, datetime.now(timezone.utc),
+            "1.2.3.4", "5.6.7.8", 1000, 502,
+        )
+        assert len(events) == 0
+
+
+class TestDNP3Dissector:
+    """Tests for DNP3 protocol dissection."""
+
+    def test_dnp3_read_request(self) -> None:
+        # DNP3 start: 0x0564, length, control, dst_addr, src_addr
+        # Then transport header + app control + function code
+        payload = b"\x05\x64"  # Start bytes
+        payload += struct.pack("<B", 20)  # Length
+        payload += struct.pack("<B", 0xC0)  # Control
+        payload += struct.pack("<H", 10)  # Destination address
+        payload += struct.pack("<H", 1)  # Source address
+        payload += b"\x00\x00"  # CRC placeholder
+        payload += b"\x00"  # Transport header
+        payload += b"\xC0"  # Application control
+        payload += b"\x01"  # Function code: Read
+
+        ts = datetime(2026, 3, 15, 14, 0, 0, tzinfo=timezone.utc)
+        events = _dissect_dnp3(payload, ts, "192.168.1.1", "192.168.1.10", 5000, 20000)
+
+        assert len(events) == 1
+        assert events[0].function_name == "Read"
+        assert events[0].ics_protocol == "dnp3"
+        assert events[0].extra["dst_address"] == 10
+
+    def test_too_short(self) -> None:
+        events = _dissect_dnp3(
+            b"\x05\x64\x0a", datetime.now(timezone.utc),
+            "1.2.3.4", "5.6.7.8", 1000, 20000,
+        )
+        assert len(events) == 0
+
+    def test_wrong_start_bytes(self) -> None:
+        payload = b"\x00\x00" + b"\x00" * 20
+        events = _dissect_dnp3(
+            payload, datetime.now(timezone.utc),
+            "1.2.3.4", "5.6.7.8", 1000, 20000,
+        )
+        assert len(events) == 0
+
+
+class TestENIPDissector:
+    """Tests for EtherNet/IP dissection."""
+
+    def test_list_identity(self) -> None:
+        # ENIP header: command(2) + length(2) + session(4) + status(4) + context(8) + options(4)
+        payload = struct.pack("<HHI", 0x0063, 0, 0)  # ListIdentity
+        payload += b"\x00" * 16  # rest of header
+
+        ts = datetime(2026, 3, 15, 14, 0, 0, tzinfo=timezone.utc)
+        events = _dissect_enip(payload, ts, "192.168.1.100", "192.168.1.1", 5000, 44818)
+
+        assert len(events) == 1
+        assert events[0].function_name == "ListIdentity"
+        assert events[0].is_request is True
+
+    def test_too_short(self) -> None:
+        events = _dissect_enip(
+            b"\x00" * 10, datetime.now(timezone.utc),
+            "1.2.3.4", "5.6.7.8", 1000, 44818,
+        )
+        assert len(events) == 0
+
+
+class TestFullPipeline:
+    """End-to-end tests for the PCAP analysis pipeline."""
+
+    def test_analyze_modbus_pcap(self, tmp_path: Path) -> None:
+        """Full pipeline: create PCAP with Modbus traffic, analyze it."""
+        packets = [
+            # Modbus Read Holding Registers request
+            (_ip(192, 168, 1, 100), _ip(192, 168, 1, 1), 5000, 502,
+             _modbus_read_request(1, 3, 0, 10)),
+            # Another Modbus request
+            (_ip(192, 168, 1, 100), _ip(192, 168, 1, 1), 5000, 502,
+             _modbus_read_request(1, 4, 100, 5)),
+            # Non-ICS traffic (HTTP)
+            (_ip(192, 168, 1, 100), _ip(10, 0, 0, 1), 5000, 80,
+             b"GET / HTTP/1.1\r\n\r\n"),
+        ]
+        pcap_path = _build_pcap(tmp_path, packets)
+
+        result = analyze_pcap(pcap_path, output_dir=tmp_path / "out")
+
+        assert result.total_packets == 3
+        assert result.protocol_summary.get("modbus_tcp", 0) >= 1
+        assert len(result.ics_events) >= 2
+        assert result.ics_events[0].ics_protocol == "modbus_tcp"
+
+    def test_asset_inventory(self, tmp_path: Path) -> None:
+        """Pipeline should build asset inventory from flows."""
+        packets = [
+            (_ip(192, 168, 1, 100), _ip(192, 168, 1, 1), 5000, 502,
+             _modbus_read_request(1, 3, 0, 10)),
+        ]
+        pcap_path = _build_pcap(tmp_path, packets)
+
+        result = analyze_pcap(pcap_path, output_dir=tmp_path / "out")
+
+        assert len(result.assets) >= 2
+        ips = {a.ip for a in result.assets}
+        assert "192.168.1.100" in ips
+        assert "192.168.1.1" in ips
+
+    def test_output_files_written(self, tmp_path: Path) -> None:
+        packets = [
+            (_ip(192, 168, 1, 100), _ip(192, 168, 1, 1), 5000, 502,
+             _modbus_read_request(1, 3, 0, 10)),
+        ]
+        pcap_path = _build_pcap(tmp_path, packets)
+        out = tmp_path / "out"
+
+        analyze_pcap(pcap_path, output_dir=out)
+
+        assert (out / "pcap-analysis-summary.json").exists()
+        assert (out / "ics-events.ndjson").exists()
+        assert (out / "asset-inventory.json").exists()
+
+    def test_empty_pcap(self, tmp_path: Path) -> None:
+        """Empty PCAP should produce empty results without errors."""
+        pcap_path = tmp_path / "empty.pcap"
+        writer = dpkt.pcap.Writer(open(pcap_path, "wb"))
+        writer.close()
+
+        result = analyze_pcap(pcap_path, output_dir=tmp_path / "out")
+
+        assert result.total_packets == 0
+        assert len(result.ics_events) == 0
+
+
+class TestFlowKey:
+    """Tests for bidirectional flow key generation."""
+
+    def test_bidirectional(self) -> None:
+        k1 = _flow_key("1.2.3.4", "5.6.7.8", 1000, 502, "tcp")
+        k2 = _flow_key("5.6.7.8", "1.2.3.4", 502, 1000, "tcp")
+        assert k1 == k2
+
+    def test_different_protocols(self) -> None:
+        k1 = _flow_key("1.2.3.4", "5.6.7.8", 1000, 502, "tcp")
+        k2 = _flow_key("1.2.3.4", "5.6.7.8", 1000, 502, "udp")
+        assert k1 != k2
+
+
+class TestPcapAnalysisResult:
+    """Tests for result serialization."""
+
+    def test_to_dict(self) -> None:
+        result = PcapAnalysisResult(
+            pcap_path="test.pcap",
+            total_packets=1000,
+            total_bytes=500000,
+            duration_seconds=60.123456,
+        )
+        d = result.to_dict()
+
+        assert d["pcap_analysis"]["total_packets"] == 1000
+        assert d["pcap_analysis"]["duration_seconds"] == 60.123


### PR DESCRIPTION
## Summary

- Adds `peat forensic` command for passive analysis of OT/ICS artifacts (disk images, log files, network captures, firmware) without touching live devices
- Integrates Fox-IT's `dissect` framework for forensic disk image analysis (E01, dd, VMDK, VHD, QCoW2) with embedded filesystem extraction (VxWorks, SquashFS, QNX, JFFS2)
- Implements tiered PCAP analysis pipeline: `dpkt` for high-speed triage (~250K pkt/sec) → protocol-specific deep dissection for Modbus TCP, DNP3, and EtherNet/IP with passive asset inventory generation
- Adds auto-detecting ICS/SCADA log parsers for SEL relay SER logs, Siemens SIPROTEC CSV exports, Schneider ClearSCADA TX/RX comms logs, and generic CSV with ECS normalization
- All operations maintain forensic integrity via streaming SHA-256/MD5 hashing with chain-of-custody metadata JSON output

## Test plan

- [x] 102 new forensic tests pass (input detection, hashing, disk image patterns, firmware extraction, log parsers, PCAP pipeline)
- [x] 452 existing PEAT tests pass with 0 regressions
- [x] End-to-end: `peat forensic` CLI with VxWorks firmware binary → detected ESTFBINR + ELF + zlib → decompressed PLC config recovered
- [x] End-to-end: `peat forensic` CLI with SEL SER log directory → auto-detect → 5 events parsed with correct severity classification → ECS NDJSON output
- [x] End-to-end: `peat forensic` CLI with Modbus/ENIP PCAP → 4 ICS events dissected, 5 assets inventoried, protocol summary generated
- [ ] Test with real-world forensic images (E01, VMDK) containing ICS artifacts
- [ ] Test with production ICS network captures (multi-GB PCAPs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)