### PR TITLE
ci: consolidate PR tasks in checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,19 +10,10 @@ If applicable, please link to the issue here (e.g., Closes: #123).
 
 See this link for more details: [Linking a PR to an Issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue)
 
-
-## Type of Change
-
-Please select the type of change your pull request introduces:
-
-- [ ] Bugfix
-- [ ] New feature
-- [ ] Documentation update
-- [ ] Other (please describe):
-
 ## Checklist
 
-Please check the following items as they're completed. Completion of all items signals that a PR is fully ready for review, in addition to removing "Draft" status from the PR.
+Please check the following items as they're completed.
+Completion of all checklist items signals to maintainers that a PR is fully ready for review.
 
 - [ ] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/peat/tree/main/.github/CONTRIBUTING.md)
 - [ ] I have included no proprietary/sensitive information in my code
@@ -32,4 +23,5 @@ Please check the following items as they're completed. Completion of all items s
 - [ ] My changes generate no new warnings
 - [ ] I have tested my code
 - [ ] I have added a description of my changes to the changelog in `CHANGELOG.rst`
-- [ ] Apply appropriate Tags to this PR (if any)
+- [ ] Apply appropriate Tags to this PR, if any (e.g. bugfix, enhancement(feature), documentation, etc.)
+- [ ] Removing "Draft" status from the PR (if applicable).


### PR DESCRIPTION
# Consolidate PR tasks in checklist

## Description

Quick change to the PR template.
Focuses the checklist to ensure that all steps are completed by the user to signal readiness for maintainer review.

You can see by the unchecked box under `Type of Change` section below that it appears that all tasks aren't complete.
As maintainers, we want to be able to glance at a PR and know it's ready to be looked at.

## Related Issue

Closes: #46

## Type of Change

Please select the type of change your pull request introduces:

- [X] CICD/Lint
- [ ] Not applicable thing that makes it look like the PR is incomplete

## Checklist

Please check the following items as they're completed. Completion of all items signals that a PR is fully ready for review, in addition to removing "Draft" status from the PR.

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/peat/tree/main/.github/CONTRIBUTING.md)
- [x] I have included no proprietary/sensitive information in my code
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my code
- [x] I have added a description of my changes to the changelog in `CHANGELOG.rst`
- [x] Apply appropriate Tags to this PR (if any)
