### PR TITLE
docs: manage CHANGELOG.rst with towncrier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,10 @@ jobs:
         with:
             fetch-tags: true
             fetch-depth: 0  # checkout full history
+
+      - name: Build changelog
+        run: towncrier build --yes
+
       - name: Install apt dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,10 @@ repos:
       files: ^(peat|tests)/
       types_or: [ python, pyi ]
       args: [ '--check' ]
+- repo: https://github.com/twisted/towncrier
+  rev: 25.8.0
+  hooks:
+    - id: towncrier-check
+      files: ^newsfragments/
+      language: system
+      entry: pdm run towncrier check

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,17 +24,5 @@ None yet after open-sourcing!
 Releases
 ========
 
-TBD
----
+.. towncrier release notes start
 
-Added
-^^^^^
-
-Changed
-^^^^^^^
-
-Removed
-^^^^^^^
-
-Other
-^^^^^

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -66,7 +66,75 @@ Here is how you can get started:
 
 #. **Update the CHANGELOG**
 
-   Record your changes in CHANGELOG.rst
+   PEAT uses `Towncrier <https://towncrier.readthedocs.io/>`_ to manage changelog entries. Towncrier provides several benefits:
+
+   - **Automated changelog generation**: No need to manually edit CHANGELOG.rst
+   - **Avoids merge conflicts**: Multiple contributors can add their own fragment files without conflicting with each other
+   - **Consistent formatting**: All entries follow the same structure
+   - **Easy contribution tracking**: Each change is linked to its Pull Request or Issue
+   - **Pre-commit validation**: Ensures fragments are properly formatted before commit
+   - **Flexible configuration**: Fragment types can be customized in ``pyproject.toml``
+
+   Instead of manually editing CHANGELOG.rst, you need to create a "news fragment" file in the ``newsfragments/`` directory.
+
+   **News Fragment Format:**
+
+   - Filename: ``<PR_NUMBER>.<TYPE>.rst``
+   - Where ``<PR_NUMBER>`` is your Pull Request number (or issue number)
+   - Where ``<TYPE>`` is one of: ``feature``, ``bugfix``, ``doc``, ``removal``, or ``misc``
+
+   **Example:** ``newsfragments/1234.feature.rst``
+
+   **Valid Fragment Types:**
+
+   - ``feature``: New features
+   - ``bugfix``: Bug fixes
+   - ``doc``: Documentation improvements
+   - ``removal``: Deprecations and removals
+   - ``misc``: Miscellaneous changes (content not shown in final changelog)
+
+   **Content:** The file should contain a brief description of your change in reStructuredText format.
+
+   **Note:** These fragment types are configured in ``pyproject.toml`` under the ``[tool.towncrier]`` section. The configuration can be customized to add, remove, or modify fragment types as needed.
+
+   **Example content:**
+
+   .. code-block:: rst
+
+      Added support for new device protocol XYZ.
+
+      This includes parsing of device configuration and status information.
+
+   **Pre-commit Validation:**
+
+   The pre-commit hooks will automatically validate your news fragments when you add or modify files in the ``newsfragments/`` directory. This ensures:
+
+   - Fragment filenames follow the correct format
+   - Fragment content is valid reStructuredText
+   - Fragment types are recognized
+   - No duplicate fragments exist
+
+   **Validation and Release Process:**
+
+   During the release process, GitHub Actions will automatically build the changelog from all accumulated news fragments when a new tag is pushed. The workflow validates that:
+
+   - All news fragments are properly formatted
+   - The changelog can be successfully generated
+   - Issue references are correctly formatted
+
+   **Manual Changelog Building (Optional):**
+
+   If you want to preview the changelog before release, you can use:
+
+   .. code-block:: bash
+
+      # Preview what the changelog will look like for version X.Y.Z
+      towncrier build --draft --version X.Y.Z
+
+      # Or use the convenience script
+      ./scripts/build_changelog.sh X.Y.Z
+
+      # This shows the changes but doesn't commit them
 
 #. **Test**
 

--- a/newsfragments/123.feature
+++ b/newsfragments/123.feature
@@ -1,0 +1,1 @@
+Added test news fragment for testing towncrier-check hook.

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "docs", "exe", "lint", "test"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:a22c6378021bdeb1a1c8434d83942ae846eb1afd210e523411aee345ba66f26d"
+content_hash = "sha256:8ba4c680cbe5368a6f8da23412190c5467f8ff42199a397f9a3d4979b90ec4f3"
 
 [[metadata.targets]]
 requires_python = ">=3.11,<3.14"
@@ -319,6 +319,19 @@ dependencies = [
 files = [
     {file = "check_sdist-1.3.2-py3-none-any.whl", hash = "sha256:a70dd4d4fe40307b60229678aa9c896f635d2c2f7929aa851792cc171c10b5e9"},
     {file = "check_sdist-1.3.2.tar.gz", hash = "sha256:9faaceca95c03ef9b8edb20db6df631e845d279b2ee6aa97d13a7c3743da7645"},
+]
+
+[[package]]
+name = "click"
+version = "8.3.2"
+requires_python = ">=3.10"
+summary = "Composable command line interface toolkit"
+dependencies = [
+    "colorama; platform_system == \"Windows\"",
+]
+files = [
+    {file = "click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d"},
+    {file = "click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5"},
 ]
 
 [[package]]
@@ -2341,6 +2354,23 @@ summary = "Style preserving TOML library"
 files = [
     {file = "tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680"},
     {file = "tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064"},
+]
+
+[[package]]
+name = "towncrier"
+version = "25.8.0"
+requires_python = ">=3.9"
+summary = "Building newsfiles for your project."
+dependencies = [
+    "click",
+    "importlib-metadata>=4.6; python_version < \"3.10\"",
+    "importlib-resources>=5; python_version < \"3.10\"",
+    "jinja2",
+    "tomli; python_version < \"3.11\"",
+]
+files = [
+    {file = "towncrier-25.8.0-py3-none-any.whl", hash = "sha256:b953d133d98f9aeae9084b56a3563fd2519dfc6ec33f61c9cd2c61ff243fb513"},
+    {file = "towncrier-25.8.0.tar.gz", hash = "sha256:eef16d29f831ad57abb3ae32a0565739866219f1ebfbdd297d32894eb9940eb1"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -756,6 +756,16 @@ exclude = [
 # https://github.com/henryiii/check-sdist
 [tool.check-sdist]
 sdist-only = ["peat", "AUTHORS", "CHANGELOG.rst", "COPYRIGHT.rst", "SECURITY.rst", "NOTICE"]
-git-only = [".*", "distribution", "examples", "scripts", "tests", "docs", ".venv", ".dockerignore", ".editorconfig", ".gitattributes", ".gitignore", "*.spec", "pdm.lock", "CODE_OF_CONDUCT.rst", "Dockerfile", "pyproject.toml", "README.md", "LICENSE", "CONTRIBUTING.rst"]
+git-only = [".*", "distribution", "examples", "scripts", "tests", "docs", ".venv", ".dockerignore", ".editorconfig", ".gitattributes", ".gitignore", "*.spec", "pdm.lock", "CODE_OF_CONDUCT.rst", "Dockerfile", "pyproject.toml", "README.md", "LICENSE", "CONTRIBUTING.rst", "newsfragments"]
 default-ignore = true
 recurse-submodules = false
+
+[tool.towncrier]
+# https://towncrier.readthedocs.io/en/stable/configuration.html
+package = "PEAT"
+package_dir = "peat"
+filename = "CHANGELOG.rst"
+title_format = "{version} ({project_date})"
+issue_format = "`#{issue} <https://github.com/sandialabs/PEAT/issues/{issue}>`_"
+all_bullets = true
+

--- a/scripts/build_changelog.sh
+++ b/scripts/build_changelog.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Manual changelog generation script for PEAT
+# Usage: ./scripts/build_changelog.sh <version>
+# Example: ./scripts/build_changelog.sh 2.0.0
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Error: Version argument required"
+    echo "Usage: $0 <version>"
+    echo "Example: $0 2.0.0"
+    exit 1
+fi
+
+VERSION=$1
+
+# Check if we're on main branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    echo "Error: Must be on main branch to build changelog"
+    echo "Current branch: $CURRENT_BRANCH"
+    exit 1
+fi
+
+# Check for uncommitted changes
+if ! git diff-index --quiet HEAD --; then
+    echo "Error: Uncommitted changes detected. Please commit or stash changes first."
+    exit 1
+fi
+
+# Build the changelog
+echo "Building changelog for version $VERSION..."
+towncrier build --version "$VERSION" --yes
+
+# Show what changed
+echo ""
+echo "Changelog updates:"
+git diff CHANGELOG.rst
+
+echo ""
+echo "Changelog successfully built!"
+echo "Review the changes above, then commit with:"
+echo "  git add CHANGELOG.rst"
+echo "  git commit -m \"docs: update changelog for v$VERSION\""


### PR DESCRIPTION
# Manage CHANGELOG.rst with towncrier

## Description

Towncrier is a tool that assembles "news fragment" files into CHANGELOG.rst.
The primary benefits are 

- a standardization around the format
- assembling the file automatically
- leveraging "news fragment" files that avoid merge conflicts when multiple PRs change CHANGELOG.rst

## Related Issue

Closes: #TBD

## Checklist

Please check the following items as they're completed.
Completion of all checklist items signals to maintainers that a PR is fully ready for review.

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/peat/tree/main/.github/CONTRIBUTING.md)
- [x] I have included no proprietary/sensitive information in my code
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my code
- [x] I have added a description of my changes to the changelog in `CHANGELOG.rst`
- [x] Apply appropriate Tags to this PR, if any (e.g. bugfix, enhancement(feature), documentation, etc.)
- [x] Removing "Draft" status from the PR (if applicable).
