### PR TITLE
feat: add peat pull --skip-scan flag

### DIFF
--- a/examples/peat-config-simple.yaml
+++ b/examples/peat-config-simple.yaml
@@ -34,6 +34,7 @@ force_online_method_tcp: false
 icmp_fallback_tcp_syn: true
 syn_port: 80
 push_skip_scan: false
+pull_skip_scan: false
 scan_sweep: false
 intensive_scan: false
 

--- a/examples/peat-config.yaml
+++ b/examples/peat-config.yaml
@@ -131,6 +131,10 @@ syn_port: 80
 # device type to be specified.
 push_skip_scan: false
 
+# Skip scanning and pull directly from hosts defined in the config file.
+# Requires hosts to be defined with a peat_module in the config.
+pull_skip_scan: false
+
 # Simple host up/down check (equivalent to "nmap -Pn <hosts>").
 # If serial ports are targeted, this will enumerate the active
 # serial ports on the host.

--- a/newsfragments/60.feature
+++ b/newsfragments/60.feature
@@ -1,0 +1,1 @@
+Add ``peat pull --skip-scan`` flag to bypass the scan phase and pull directly from hosts defined in a config file. Per-host ``peat_module`` mappings in the ``hosts`` list are respected; a single ``-d`` device type can be used as a fallback. The ``-i``/``-f`` argument is no longer required when a config file with a ``hosts`` list is supplied.

--- a/peat/api/pull_api.py
+++ b/peat/api/pull_api.py
@@ -1,13 +1,17 @@
 import timeit
 from operator import itemgetter
 
-from peat import __version__, config, consts, datastore, log, module_api, state, utils
+from peat import PeatError, __version__, config, consts, datastore, log, module_api, state, utils
+from peat.protocols import hosts_to_ips, sort_ips
 
 from .scan_api import scan
 
 
 def pull(
-    targets: list[str], comm_type: consts.AllowedCommTypes, device_types: list[str]
+    targets: list[str],
+    comm_type: consts.AllowedCommTypes,
+    device_types: list[str],
+    skip_scan: bool = False,
 ) -> dict[str, dict | list | str | float | int] | None:
     """Pull from devices.
 
@@ -19,23 +23,71 @@ def pull(
             - ``broadcast_ip``
             - ``serial``
         device_types: Names of device modules or module aliases to use
+        skip_scan: If device verification (scanning) should be skipped.
+            NOTE: this currently only applies to unicast_ip devices.
 
     Returns:
         :ref:`pull-summary` as a :class:`dict`, or :obj:`None` if an error occurred
     """
-    # TODO: option to skip scan and manually specify devices to pull
-    scan_summary = scan(targets, comm_type, device_types)
+    if skip_scan:
+        log.warning(f"Skipping verification scan and pulling from {len(targets)} targets")
 
-    if not scan_summary or not scan_summary["hosts_verified"]:
-        log.error("Pull failed: no devices were found")
-        state.error = True
-        return None
+        ips = sort_ips(hosts_to_ips(targets))
+        if not ips:
+            log.error("Pull failed: no IP targets were valid")
+            state.error = True
+            return None
 
-    # * Combine any duplicate devices *
-    datastore.deduplicate()
+        # Build per-IP module map from YAML config hosts
+        host_module_map: dict = {}
+        for host in config.HOSTS or []:
+            ip = host.get("identifiers", {}).get("ip")
+            peat_module = host.get("peat_module")
+            if ip and peat_module:
+                resolved = module_api.lookup_types([peat_module], filter_attr="ip_methods")
+                if resolved:
+                    host_module_map[ip] = resolved[0]
 
-    # TODO: hack. Make this list the user input if scan is skipped.
-    devices = datastore.verified
+        # Fallback to the explicitly specified device types when no per-host mapping exists
+        fallback_modules = module_api.lookup_types(device_types, filter_attr="ip_methods")
+        if len(fallback_modules) > 1 and not host_module_map:
+            raise PeatError(
+                "More than 1 device type specified with --skip-scan and no per-host "
+                "'peat_module' found in YAML config. Specify a single module using '-d' or "
+                "add 'peat_module' to each host entry in the YAML config."
+            )
+        fallback_module = fallback_modules[0] if len(fallback_modules) == 1 else None
+
+        devices = []
+        for ip in ips:
+            module = host_module_map.get(ip) or fallback_module
+            if module is None:
+                log.error(f"No module resolved for {ip}, unable to pull")
+                state.error = True
+                return None
+
+            dev = datastore.get(ip)
+            dev._is_active = True
+            dev._is_verified = True
+            dev._module = module
+            devices.append(dev)
+
+        if not devices:
+            log.error("Pull failed: no valid devices to pull from")
+            state.error = True
+            return None
+    else:
+        scan_summary = scan(targets, comm_type, device_types)
+
+        if not scan_summary or not scan_summary["hosts_verified"]:
+            log.error("Pull failed: no devices were found")
+            state.error = True
+            return None
+
+        # * Combine any duplicate devices *
+        datastore.deduplicate()
+
+        devices = datastore.verified
 
     # * Pull from all devices specified *
     log.info(f"Beginning pull for {len(devices)} devices")
@@ -75,7 +127,7 @@ def pull(
         "peat_run_id": str(consts.RUN_ID),
         "pull_duration": pull_duration,
         "pull_modules": module_api.lookup_names(device_types),
-        "pull_targets": scan_summary["scan_targets"],
+        "pull_targets": targets if skip_scan else scan_summary["scan_targets"],
         "pull_original_targets": targets,
         "pull_devices": [dev.get_id() for dev in devices],
         "pull_comm_type": comm_type,

--- a/peat/cli_args.py
+++ b/peat/cli_args.py
@@ -237,6 +237,11 @@ peat pull -d clx -i 192.0.2.0/24 -c peat-config.yaml
 # Useful for verifying configuration options before pulling the
 # metaphorical trigger on a pull.
 peat pull --dry-run -d clx -i 192.0.2.0/24
+
+# Skip the scan phase and pull directly from hosts defined in a config file.
+# Hosts must have a peat_module specified in the config. The -i argument is
+# not required when a config file with a hosts list is supplied.
+peat pull --skip-scan -c peat-config.yaml
 """  # End pull examples
 
 
@@ -848,6 +853,15 @@ def build_argument_parser(version: str = "0.0.0") -> argparse.ArgumentParser:
         'of a PEAT module, device vendor, device type (e.g. "plc"), '
         "or other aliases. This can be a single string or a space-separated list of strings.",
     )
+    pull_parser.add_argument(
+        "--skip-scan",
+        action="store_true",
+        default=None,
+        dest="pull_skip_scan",
+        help="Skip scanning and verification of hosts before pulling, "
+        "and assume all hosts are online and valid devices. NOTE: "
+        "this requires a single device type to be specified.",
+    )
 
     # !! NOTE !!
     # input_source is duplicated between parse and push because the order they are
@@ -933,7 +947,8 @@ def build_argument_parser(version: str = "0.0.0") -> argparse.ArgumentParser:
             "and other information sources, such as imported scan "
             "results.",
         )
-        host_group = subp.add_mutually_exclusive_group(required=True)
+        # pull can omit host args when a YAML config with hosts is provided
+        host_group = subp.add_mutually_exclusive_group(required=subp is not pull_parser)
         host_group.add_argument(
             "-i",
             "--ip",

--- a/peat/cli_main.py
+++ b/peat/cli_main.py
@@ -259,7 +259,9 @@ def oneshot_main(args: dict[str, Any]) -> bool:
             return True
 
         elif args["func"] == "pull":
-            pull_results = pull(targets, comm_type, sorted_device_types)
+            pull_results = pull(
+                targets, comm_type, sorted_device_types, skip_scan=config.PULL_SKIP_SCAN
+            )
 
             if not pull_results:
                 return False
@@ -383,8 +385,27 @@ def get_targets(args: dict[str, Any]) -> TargetsType:
             comm_type = "serial"
             id_key = "serial_port"
             targets = args["port_list"]  # type: list[str]
+        elif config.HOSTS:
+            # No host argument supplied — derive targets from the YAML config hosts
+            comm_type = "unicast_ip"
+            targets = []
+
+            for host in config.HOSTS:
+                ip = host.get("identifiers", {}).get("ip")
+                if ip:
+                    targets.append(ip)
+
+                    if host.get("peat_module"):
+                        module_set.add(host["peat_module"])
+
+            if not targets:
+                raise PeatError(
+                    "No IP hosts found in YAML config. Add 'identifiers: ip:' to each host entry."
+                )
         else:
-            raise PeatError("Bad target arguments")
+            raise PeatError(
+                "No hosts specified. Provide -i/-s/-f/-b or define hosts in a YAML config with -c."
+            )
 
         if config.DEBUG >= 2:
             log.debug(

--- a/peat/settings.py
+++ b/peat/settings.py
@@ -161,6 +161,17 @@ class Configuration(SettingsManager):
        (the ``-d`` argument on the :term:`CLI`)
     """
 
+    PULL_SKIP_SCAN: bool = False
+    """
+    Skip scanning and verification of hosts before pulling and assume
+    all hosts are online and valid devices.
+
+    .. note::
+       This requires either a single device type (the ``-d`` argument on
+       the :term:`CLI`) or per-host ``peat_module`` mappings defined in
+       the ``hosts`` list of a YAML config file.
+    """
+
     SCAN_SWEEP: bool = False
     """
     Simple host up/down check (equivalent to ``nmap -Pn <hosts>``).

--- a/tests/api/test_pull_api.py
+++ b/tests/api/test_pull_api.py
@@ -1,6 +1,129 @@
-from peat import datastore, pull
+from unittest.mock import MagicMock
+
+import pytest
+
+from peat import PeatError, config, datastore, state
+from peat.api.pull_api import pull
 
 
 def test_pull_static(mocker):
     mocker.patch.object(datastore, "objects", [])
     assert not pull([], "", [])
+
+
+# ---------------------------------------------------------------------------
+# pull --skip-scan
+# ---------------------------------------------------------------------------
+
+
+def _mock_module(name="MockModule"):
+    """Return a minimal DeviceModule stand-in that reports a successful pull."""
+    mod = MagicMock()
+    mod.__name__ = name
+    mod.pull.return_value = True
+    mod.elastic = MagicMock(return_value={})
+    return mod
+
+
+@pytest.fixture
+def _skip_scan_base(mocker, tmp_path):
+    """Apply patches common to all skip-scan tests: clean datastore, reset
+    error state, redirect file output to tmp_path, and stub out summary
+    saving so no real files are written."""
+    mocker.patch.object(datastore, "objects", [])
+    mocker.patch.dict(state["CONFIG"], {"error": False})
+    mocker.patch.dict(
+        config["CONFIG"],
+        {"DEVICE_DIR": tmp_path / "devices", "TEMP_DIR": tmp_path / "temp"},
+    )
+    mocker.patch("peat.api.pull_api.utils.save_results_summary")
+    mocker.patch("peat.api.pull_api.module_api.lookup_names", return_value=[])
+
+
+@pytest.mark.usefixtures("_skip_scan_base")
+def test_returns_none_with_no_valid_ips(mocker):
+    """An empty target list should short-circuit and return None."""
+    mocker.patch.dict(config["CONFIG"], {"HOSTS": []})
+    mocker.patch("peat.api.pull_api.module_api.lookup_types", return_value=[])
+
+    result = pull([], "unicast_ip", [], skip_scan=True)
+
+    assert result is None
+
+
+@pytest.mark.usefixtures("_skip_scan_base")
+def test_raises_with_multiple_modules_and_no_host_map(mocker):
+    """Specifying more than one device type without per-host peat_module
+    mappings in the config is ambiguous and should raise PeatError."""
+    mocker.patch.dict(config["CONFIG"], {"HOSTS": []})
+    mod1, mod2 = _mock_module("Mod1"), _mock_module("Mod2")
+    mocker.patch("peat.api.pull_api.module_api.lookup_types", return_value=[mod1, mod2])
+
+    with pytest.raises(PeatError):
+        pull(["192.168.0.1"], "unicast_ip", ["Mod1", "Mod2"], skip_scan=True)
+
+
+@pytest.mark.usefixtures("_skip_scan_base")
+def test_uses_fallback_module_when_no_host_map(mocker):
+    """When no per-host mapping exists but a single -d module is given,
+    that module should be used for all targets."""
+    mocker.patch.dict(config["CONFIG"], {"HOSTS": []})
+    mod = _mock_module()
+    mocker.patch("peat.api.pull_api.module_api.lookup_types", return_value=[mod])
+
+    result = pull(["192.168.0.1"], "unicast_ip", ["MockModule"], skip_scan=True)
+
+    assert result is not None
+    dev = datastore.get("192.168.0.1")
+    assert dev._module is mod
+
+
+@pytest.mark.usefixtures("_skip_scan_base")
+def test_uses_per_host_module_from_config(mocker):
+    """A peat_module defined under a host entry in the YAML config should
+    take precedence over any fallback module."""
+    mocker.patch.dict(
+        config["CONFIG"],
+        {
+            "HOSTS": [{"identifiers": {"ip": "192.168.0.1"}, "peat_module": "MockModule"}],
+        },
+    )
+    mod = _mock_module()
+    mocker.patch(
+        "peat.api.pull_api.module_api.lookup_types",
+        side_effect=lambda names, **_: [mod] if names else [],
+    )
+
+    result = pull(["192.168.0.1"], "unicast_ip", [], skip_scan=True)
+
+    assert result is not None
+    dev = datastore.get("192.168.0.1")
+    assert dev._module is mod
+
+
+@pytest.mark.usefixtures("_skip_scan_base")
+def test_skips_ip_with_no_resolved_module(mocker):
+    """An IP that cannot be mapped to any module should cause pull to
+    return None and set state.error to True."""
+    mocker.patch.dict(config["CONFIG"], {"HOSTS": []})
+    mocker.patch("peat.api.pull_api.module_api.lookup_types", return_value=[])
+
+    result = pull(["192.168.0.1"], "unicast_ip", [], skip_scan=True)
+
+    assert result is None
+    assert state.error is True
+
+
+@pytest.mark.usefixtures("_skip_scan_base")
+def test_devices_marked_active_and_verified(mocker):
+    """Devices built by skip-scan should be pre-marked as active and
+    verified so the pull loop treats them as confirmed targets."""
+    mocker.patch.dict(config["CONFIG"], {"HOSTS": []})
+    mod = _mock_module()
+    mocker.patch("peat.api.pull_api.module_api.lookup_types", return_value=[mod])
+
+    pull(["192.168.0.1"], "unicast_ip", ["MockModule"], skip_scan=True)
+
+    dev = datastore.get("192.168.0.1")
+    assert dev._is_active is True
+    assert dev._is_verified is True

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -30,3 +30,16 @@ def test_parse_peat_arguments(mocker):
     assert isinstance(result, argparse.Namespace)
     assert result.verbose is True
     assert result.debug == 1
+
+
+def test_pull_skip_scan_arg(mocker):
+    mocker.patch("sys.argv", ["peat", "pull", "--skip-scan"])
+    result = cli_args.parse_peat_arguments()
+    assert isinstance(result, argparse.Namespace)
+    assert result.pull_skip_scan is True
+
+
+def test_pull_skip_scan_default_none(mocker):
+    mocker.patch("sys.argv", ["peat", "pull", "-i", "192.168.0.1"])
+    result = cli_args.parse_peat_arguments()
+    assert not result.pull_skip_scan


### PR DESCRIPTION

# Add peat pull --skip-scan flag

## Description

- Add --skip-scan CLI flag to bypass scan phase and pull directly from hosts defined in a config file; removes requirement for -i/-f when a config with a hosts list is supplied
- Per-host peat_module mappings in the hosts list are respected; a single -d device type can be used as a fallback
- Add pull_skip_scan setting to Configuration and both example config files
- Add unit tests for skip-scan logic in pull_api and cli_args


## Related Issue

Closes #60 

## Checklist

Please check the following items as they're completed.
Completion of all checklist items signals to maintainers that a PR is fully ready for review.

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/peat/tree/main/.github/CONTRIBUTING.md)
- [x] I have included no proprietary/sensitive information in my code
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my code
- [x] I have added a description of my changes to the changelog in `CHANGELOG.rst`
- [x] Apply appropriate Tags to this PR, if any (e.g. bugfix, enhancement(feature), documentation, etc.)
- [x] Removing "Draft" status from the PR (if applicable).
