### PR TITLE
(WIP) fix(build): pre-commit/CI checks fail on a clean `main`

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "docs", "exe", "lint", "test"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:8ba4c680cbe5368a6f8da23412190c5467f8ff42199a397f9a3d4979b90ec4f3"
+content_hash = "sha256:a22c6378021bdeb1a1c8434d83942ae846eb1afd210e523411aee345ba66f26d"
 
 [[metadata.targets]]
 requires_python = ">=3.11,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -764,6 +764,11 @@ recurse-submodules = false
 # https://towncrier.readthedocs.io/en/stable/configuration.html
 package = "PEAT"
 package_dir = "peat"
+# News fragments live in the top-level ``newsfragments/`` directory (see
+# CONTRIBUTING.rst). Without this, towncrier defaults to looking in
+# ``<package_dir>/<package>/newsfragments`` (i.e. ``peat/PEAT/newsfragments``),
+# which does not exist, so ``towncrier build``/``check`` silently find nothing.
+directory = "newsfragments"
 filename = "CHANGELOG.rst"
 title_format = "{version} ({project_date})"
 issue_format = "`#{issue} <https://github.com/sandialabs/PEAT/issues/{issue}>`_"


### PR DESCRIPTION
# fix(build): pre-commit/CI checks fail on a clean `main`

## Description

Two repository tooling checks fail on a fresh checkout of `main`, independent of any feature code:

- **`pdm.lock` content hash is stale.** It was generated by an older PDM, so `pdm lock --check` (and frozen installs / CI) fail under PDM 2.27.0 even though no dependencies changed. This PR regenerates the hash  **no dependency versions are altered** (only the `content_hash` line changes).
- **Towncrier fragments directory.** `[tool.towncrier]` omitted `directory`, so towncrier resolved fragments to `<package_dir>/<package>/newsfragments` (`peat/PEAT/newsfragments`), which does not exist. Fragments actually live in the top-level `newsfragments/` (per `CONTRIBUTING.rst`), so `towncrier build`/`check` silently found nothing, meaning any branch adding a fragment fails the `towncrier-check` pre-commit hook. This PR sets `directory = "newsfragments"`.

Verified locally: `pdm lock --check` to a clean exit, then `pdm run towncrier build --draft` now renders fragments under **Features**; full suite passes (**364 passed, 18 skipped**).

## Related Issue

Closes: #65  

## Checklist

- [x] This PR conforms to the process detailed in the Contributing Guide
- [x] I have included no proprietary/sensitive information in my code
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - N/A no documentation changes required.
- [x] My changes generate no new warnings
- [x] I have tested my code
- [ ] I have added a description of my changes to the changelog in `CHANGELOG.rst`
- [x] Apply appropriate Tags to this PR, if any (e.g. bugfix, enhancement(feature), documentation, etc.)
- [x] Removing "Draft" status from the PR (if applicable).