### PR TITLE
ci: Added CI check for Towncrier change log fragments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,8 +20,6 @@ Completion of all checklist items signals to maintainers that a PR is fully read
 - [ ] I have performed a self-review of my code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
 - [ ] I have tested my code
-- [ ] I have added a description of my changes to the changelog in `CHANGELOG.rst`
-- [ ] Apply appropriate Tags to this PR, if any (e.g. bugfix, enhancement(feature), documentation, etc.)
-- [ ] Removing "Draft" status from the PR (if applicable).
+- [ ] I have removed the "Draft" status from the PR (if applicable).
+- [ ] I have created the appropriate towncrier news fragments for my PR (See `Update the CHANGELOG` in the [Contributing Guide](https://github.com/sandialabs/peat/tree/main/.github/CONTRIBUTING.md))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build Documentation (HTML and manpage)
     runs-on: ubuntu-24.04
     steps:
-      # This will block outbound connections that aren't explictly allowed
+      # This will block outbound connections that aren't explicitly allowed
       # If this causes a pipeline to fail, investigate what endpoints were blocked.
       # If they are legitimate, then change to audit mode, run pipeline and collect
       # endpoints from StepSecurity report, update list of endpoints, then change back

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build documentation (HTML)
     runs-on: ubuntu-24.04
     steps:
-      # This will block outbound connections that aren't explictly allowed
+      # This will block outbound connections that aren't explicitly allowed
       # If this causes a pipeline to fail, investigate what endpoints were blocked.
       # If they are legitimate, then change to audit mode, run pipeline and collect
       # endpoints from StepSecurity report, update list of endpoints, then change back

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,15 +29,40 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            raw.githubusercontent.com:443
+            pdm-project.org:443
+            pdm.fming.dev:443
+            pypi.org:443
+            files.pythonhosted.org:443
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with: 
+            persist-credentials: true
+            fetch-depth: 0
+            ref: main
+      - name: Setup PDM
+        uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0 # v4
         with:
-            fetch-tags: true
-            fetch-depth: 0  # checkout full history
-
-      # - name: Build changelog
-      #  run: towncrier build --yes
+          python-version: "3.12"
+          cache: true
+      - name: Install dependencies
+        run: pdm sync -G towncrier
+      - name: Build draft changelog
+        run: pdm run towncrier build --yes
+      - name: Update CHANGELOG.rst & push
+        run: |
+          # GITHUB_REF is "refs/tags/v1.2.3", strip the prefix:
+          TAG=${GITHUB_REF#refs/tags/}
+          echo "- $TAG: automated release entry on $(date +'%Y-%m-%d')" >> ChangeLog.rst
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.rst
+          git commit -m "docs: Updated CHANGELOG for tag $TAG [skip ci]"
+          git push
 
       - name: Install apt dependencies
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,73 @@ jobs:
           types: >
             build|chore|ci|docs|doc|feat|fix|bug|minor|patch|perf|style|refactor|test|tests|revert|deps|dependencies|sec|security|deprecate
 
+  check-newsfragments:
+    name: Changelog Fragment Check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0s
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            raw.githubusercontent.com:443
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: News Fragments Added
+        shell: bash
+        run: |
+          set -euo pipefail
+          
+          PR_NUM=${{ github.event.pull_request.number }}
+
+          # require at least one fragment file named PR.<category>
+          if ! ls newsfragments/${PR_NUM}.* >/dev/null 2>&1; then
+            echo "::error ::Missing newsfragment file: newsfragments/${PR_NUM}.*"
+            echo "Please add at least one fragment (e.g. newsfragments/${PR_NUM}.feature or newsfragments/${PR_NUM}.bugfix) so towncrier can pick it up for the changelog. It's now required for all PRs, even minor changes."
+            echo "Refer to the 'Update the CHANGELOG' section in CONTRIBUTING.rst"
+            exit 1
+          else
+            echo -e "Found fragment(s):"
+            ls newsfragments/${PR_NUM}.*
+          fi
+
+  # This verifies that the release.yml version will pass too
+  check-changelog: 
+    name: Changelog Construction Check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      discussions: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0s
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            raw.githubusercontent.com:443
+            pdm-project.org:443
+            pdm.fming.dev:443
+            pypi.org:443
+            files.pythonhosted.org:443
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Setup PDM
+        uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0 # v4
+        with:
+          python-version: "3.12"
+          cache: true
+      - name: Install dependencies
+        run: pdm sync -G towncrier
+      - name: Build draft changelog
+        run: pdm run towncrier build --draft
+
   code-quality:
     name: Code Quality Checks
     runs-on: ubuntu-24.04

--- a/AUTHORS
+++ b/AUTHORS
@@ -32,3 +32,4 @@ Timothy Schulz
 Trevor Sorrells
 Walter Weiffenbach
 William Joslin
+Bryan Watson

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -75,12 +75,14 @@ Here is how you can get started:
    - **Pre-commit validation**: Ensures fragments are properly formatted before commit
    - **Flexible configuration**: Fragment types can be customized in ``pyproject.toml``
 
-   Instead of manually editing CHANGELOG.rst, you need to create a "news fragment" file in the ``newsfragments/`` directory.
+   Instead of manually editing CHANGELOG.rst, you need to create at least one "news fragment" file in the ``newsfragments/`` directory.
+   You can manually create these files manually or use `pdm run towncrier create`. *Note that you must provide the Pull Request number 
+   when towncrier asks for an issue number in the prompt.* You can skip the prompt by running something like `pdm run towncrier create 1234.feature`.
 
    **News Fragment Format:**
 
-   - Filename: ``<PR_NUMBER>.<TYPE>.rst``
-   - Where ``<PR_NUMBER>`` is your Pull Request number (or issue number)
+   - Filename: ``<PR_NUMBER>.<TYPE>``
+   - Where ``<PR_NUMBER>`` is your Pull Request number
    - Where ``<TYPE>`` is one of: ``feature``, ``bugfix``, ``doc``, ``removal``, or ``misc``
 
    **Example:** ``newsfragments/1234.feature.rst``
@@ -129,7 +131,7 @@ Here is how you can get started:
    .. code-block:: bash
 
       # Preview what the changelog will look like for version X.Y.Z
-      towncrier build --draft --version X.Y.Z
+      pdm run towncrier build --draft --version X.Y.Z
 
       # Or use the convenience script
       ./scripts/build_changelog.sh X.Y.Z

--- a/newsfragments/80.misc
+++ b/newsfragments/80.misc
@@ -1,0 +1,1 @@
+Added a check to ensure that all PRs include a towncrier new fragment for the changelog

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "docs", "exe", "lint", "test"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:a22c6378021bdeb1a1c8434d83942ae846eb1afd210e523411aee345ba66f26d"
+content_hash = "sha256:dcd8b382ae881947d551b496b02c7abced73458a69fdf2138ffb841a72598bcf"
 
 [[metadata.targets]]
 requires_python = ">=3.11,<3.14"

--- a/peat/protocols/enip/enip_packets.py
+++ b/peat/protocols/enip/enip_packets.py
@@ -187,7 +187,7 @@ class EncapData(Packet):
 # Bugfix (cegoes, 01/10/2025): Scapy 2.6.0 changed dissection behavior.
 # Previously, if the bytes passed were too short to fully dissect, then
 # the dissection would end between fields. Remaining fields would be kept
-# with default values. The new behavior requires these points to be explictly
+# with default values. The new behavior requires these points to be explicitly
 # defined, using MayEnd.
 # Details: https://github.com/secdev/scapy/pull/4012
 class GetAttributesAllResponse(Packet):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,6 +309,7 @@ dev = [
     "pylint",
     # Used for pre-commit hooks (https://pre-commit.com)
     "pre-commit",
+    "towncrier",
 ]
 docs = [
     # Sphinx is the primary tool that builds the docs
@@ -780,7 +781,7 @@ package_dir = "peat"
 # which does not exist, so ``towncrier build``/``check`` silently find nothing.
 directory = "newsfragments"
 filename = "CHANGELOG.rst"
+create_add_extension = false
 title_format = "{version} ({project_date})"
 issue_format = "`#{issue} <https://github.com/sandialabs/PEAT/issues/{issue}>`_"
 all_bullets = true
-


### PR DESCRIPTION
# Added CI check for Towncrier change log fragments

## Description
New check looks at the PRs commit history and requires at least one newfragments/<PR Number>.x file for all PRs. This is how we'll track and update changes to changelog.rst for releases.

### Changes
- ci: Added `News Fragments Added` check
- ci: Removed redundant checklist options from default PR description
- docs: Fixed some typos
- build: Adjusted pyproject.toml's configuration for towncrier pre-commit checks

## Checklist

Please check the following items as they're completed.
Completion of all checklist items signals to maintainers that a PR is fully ready for review.

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/peat/tree/main/.github/CONTRIBUTING.md)
- [x] I have included no proprietary/sensitive information in my code
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my code
- [x] Removing "Draft" status from the PR (if applicable).
