### PR TITLE
feat: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS
+#
+# Each line is a file pattern followed by one or more owners, using their
+# GitHub usernames. These owners will be requested for review when a pull
+# request changes matching code, and are the point of contact for questions
+# about that area of the codebase.
+#
+# This is used in addition to AUTHORS, which tracks the list of all
+# contributors to the project.
+#
+# For more info, see:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo, unless a later match takes precedence
+* @GhostofGoes

--- a/newsfragments/74.feature.rst
+++ b/newsfragments/74.feature.rst
@@ -1,0 +1,1 @@
+Added a ``CODEOWNERS`` file to provide clear ownership of the codebase and automatically request reviews from maintainers on pull requests.


### PR DESCRIPTION
## Description

Adds a `CODEOWNERS` file at the repo root so PRs are auto-assigned reviewers and code ownership is clear without digging through git blame. Default owner is set to `@GhostofGoes` (dominant contributor). Also adds the required towncrier news fragment (`newsfragments/74.feature.rst`).

## Related Issue

Closes: #74

## Checklist

- [x] This PR conforms to the process detailed in the Contributing Guide
- [x] I have included no proprietary/sensitive information in my code
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my code
- [x] I have added a description of my changes to the changelog (via towncrier news fragment)
- [x] Apply appropriate Tags to this PR, if any (e.g. bugfix, enhancement(feature), documentation, etc.)
- [x] Removing "Draft" status from the PR (if applicable).