### PR TITLE
fix: Added missing encrypt/decrypt examples to CLI

### DIFF
--- a/newsfragments/83.bugfix
+++ b/newsfragments/83.bugfix
@@ -1,0 +1,1 @@
+fix: Added missing encrypt/decrypt examples to CLI and fixed exception when an invalid example is requested

--- a/peat/cli_args.py
+++ b/peat/cli_args.py
@@ -408,6 +408,33 @@ peat heat -e --heat-date-range "2021-07-15T00:00:00.000 - 2021-07-16T12:34:12.14
 peat heat -e -c peat-config.yaml
 """  # End HEAT examples
 
+encrypt_results_examples = """
+# See the "Encrypting results" section in the PEAT documentation
+
+# Encrypt the files in the -f directory with the user password and store the results in the -w directory
+peat encrypt-results -f '~/peat/results' -p secret -w '~/peat/encrypted_results'
+"""  # End encrypt-results examples
+
+decrypt_results_examples = """
+# See the "Decrypting results" section in the PEAT documentation
+
+# Decrypt the files in the -f directory with the user password and store the results in the -w directory
+peat encrypt-results -f '~/peat/encrypted_results' -p secret -w '~/peat/results'
+"""  # End decrypt-results examples
+
+encrypt_config_examples = """
+# See the "peat encrypt-config" section in the PEAT documentation
+
+# Encrypt the config files in the -f directory with the user password and store the encrypted result in the -w directory
+peat encrypt-config -f '<my_path>/example_config.yaml' -p secret -w '<my_path>/encrypted_config.yaml'
+"""  # End encrypt-config examples
+
+decrypt_config_examples = """
+# See the "peat decrypt-config" section in the PEAT documentation
+
+# Decrypt the config files in the -f directory with the user password and store the result in the -w directory
+peat decrypt-config -f '<my_path>/encrypted_config.yaml' -p secret -w '<my_path>/example_config.yaml'
+"""  # End decrypt-config examples
 
 ALL_EXAMPLES: dict[str, str] = {
     "scan": scan_examples,
@@ -416,6 +443,10 @@ ALL_EXAMPLES: dict[str, str] = {
     "push": push_examples,
     "pillage": pillage_examples,
     "heat": heat_examples,
+    "encrypt_results": encrypt_results_examples,
+    "decrypt_results": decrypt_results_examples,
+    "encrypt_config": encrypt_config_examples,
+    "decrypt_config": decrypt_config_examples,
 }
 
 

--- a/peat/cli_main.py
+++ b/peat/cli_main.py
@@ -80,6 +80,16 @@ def run_peat(args: dict[str, Any], start_time: float) -> None:
 
     # Print examples for the current sub-command, e.g. "scan"
     if args.get("examples"):
+        func = args["func"]
+        if not func or func not in cli_args.ALL_EXAMPLES:
+            available = ", ".join(sorted(cli_args.ALL_EXAMPLES))
+            print(  # noqa: T201
+                f"No examples found for function: {func!r}\n"
+                f"Available functions with examples: {available}",
+                flush=True,
+            )
+            sys.exit(1)
+
         print(cli_args.ALL_EXAMPLES[args["func"]].strip(), flush=True)  # noqa: T201
         sys.exit(0)
 


### PR DESCRIPTION
# fix: Added missing encrypt/decrypt examples to CLI

## Description

Added missing encrypt/decrypt examples to CLI and fixed exception when an invalid example is requested

## Related Issue

Closes: #82

See this link for more details: [Issue 82](https://github.com/sandialabs/PEAT/issues/82)

## Checklist

Please check the following items as they're completed.
Completion of all checklist items signals to maintainers that a PR is fully ready for review.

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/peat/tree/main/.github/CONTRIBUTING.md)
- [x] I have included no proprietary/sensitive information in my code
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my code
- [x] I have removed the "Draft" status from the PR (if applicable).
- [x] I have created the appropriate towncrier news fragments for my PR (See `Update the CHANGELOG` in the [Contributing Guide](https://github.com/sandialabs/peat/tree/main/.github/CONTRIBUTING.md))
